### PR TITLE
Add platforms and connectivity for verified validation

### DIFF
--- a/drivers/valetudo/driver.compose.json
+++ b/drivers/valetudo/driver.compose.json
@@ -5,6 +5,8 @@
     "de": "Valetudo Saugroboter"
   },
   "class": "vacuumcleaner",
+  "platforms": ["local"],
+  "connectivity": ["lan"],
   "images": {
     "small": "{{driverAssetsPath}}/images/small.png",
     "large": "{{driverAssetsPath}}/images/large.png"


### PR DESCRIPTION
## Summary
- Add `"platforms": ["local"]` and `"connectivity": ["lan"]` to `driver.compose.json`
- Required by Homey's `verified` validation level
- These were lost when git history was rewritten after PR #1

## Test plan
- [ ] Verify "Validate Homey App" CI passes