### PR TITLE
Reference homey-app-store environment in publish workflow

### DIFF
--- a/.github/workflows/homey-app-publish.yml
+++ b/.github/workflows/homey-app-publish.yml
@@ -6,6 +6,7 @@ jobs:
   main:
     name: Publish Homey App
     runs-on: ubuntu-latest
+    environment: homey-app-store
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Add `environment: homey-app-store` to the publish workflow job
- Without this, the `HOMEY_PAT` secret stored in the environment is not accessible, causing the publish action to stall on an interactive login prompt

## Test plan
- [ ] Merge, then trigger "Publish Homey App" workflow and verify it authenticates without stalling