### PR TITLE
Use publish validation level, restrict push triggers to main

### DIFF
--- a/.github/workflows/homey-app-validate.yml
+++ b/.github/workflows/homey-app-validate.yml
@@ -2,14 +2,15 @@ name: Validate Homey App
 on:
   workflow_dispatch:
   push:
+    branches: [main]
   pull_request:
 
 jobs:
-  main:
+  validate:
     name: Validate Homey App
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: athombv/github-action-homey-app-validate@master
         with:
-          level: verified
+          level: publish


### PR DESCRIPTION
Change validation from verified to publish level for community app publishing. Restrict push-triggered validation to main branch only.