### PR TITLE
Add readme.txt for App Store

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,3 @@
+Valetudo for Homey brings your Valetudo-powered robot vacuum into the Homey ecosystem. Control cleaning, monitor battery, and manage multi-floor setups directly from Homey. Supports MQTT and HTTP connections with live map snapshots in a widget.
+
+Compatible with any robot vacuum running Valetudo, including Roborock, Dreame, and other supported brands. Features include start/stop cleaning, fan speed control, floor switching via SSH, locate robot, and return to dock.


### PR DESCRIPTION
## Summary
- Adds `readme.txt` as required by Homey App Store publishing guidelines
- Plain text, no markdown or URLs, 1-2 paragraphs describing the app

## Test plan
- [ ] Verify `homey app validate --level publish` passes