### PR TITLE
Remove xlarge image reference

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -22,8 +22,7 @@
   "permissions": [],
   "images": {
     "small": "/assets/images/small.png",
-    "large": "/assets/images/large.png",
-    "xlarge": "/assets/images/xlarge.png"
+    "large": "/assets/images/large.png"
   },
   "author": {
     "name": "Mads Fox",


### PR DESCRIPTION
## Summary
- Removes `xlarge` image reference from `.homeycompose/app.json`
- The `xlarge` (2048x1536) image is only required at `verified` validation level
- The file `assets/images/xlarge.png` doesn't exist, which would cause validation failure

## Test plan
- [ ] Verify `homey app validate --level publish` passes