### PR TITLE
Fix driver icon viewBox to 960x960

### DIFF
--- a/drivers/valetudo/assets/icon.svg
+++ b/drivers/valetudo/assets/icon.svg
@@ -1,8 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <circle cx="50" cy="50" r="45" fill="none" stroke="#1a73e8" stroke-width="4"/>
-  <circle cx="50" cy="50" r="35" fill="none" stroke="#1a73e8" stroke-width="2"/>
-  <circle cx="50" cy="38" r="6" fill="#1a73e8"/>
-  <rect x="38" y="55" width="24" height="6" rx="3" fill="#1a73e8"/>
-  <line x1="20" y1="50" x2="30" y2="50" stroke="#1a73e8" stroke-width="2" stroke-linecap="round"/>
-  <line x1="70" y1="50" x2="80" y2="50" stroke="#1a73e8" stroke-width="2" stroke-linecap="round"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 960">
+  <circle cx="480" cy="480" r="432" fill="none" stroke="#1a73e8" stroke-width="38.4"/>
+  <circle cx="480" cy="480" r="336" fill="none" stroke="#1a73e8" stroke-width="19.2"/>
+  <circle cx="480" cy="365" r="57.6" fill="#1a73e8"/>
+  <rect x="365" y="528" width="230.4" height="57.6" rx="28.8" fill="#1a73e8"/>
+  <line x1="192" y1="480" x2="288" y2="480" stroke="#1a73e8" stroke-width="19.2" stroke-linecap="round"/>
+  <line x1="672" y1="480" x2="768" y2="480" stroke="#1a73e8" stroke-width="19.2" stroke-linecap="round"/>
 </svg>


### PR DESCRIPTION
## Summary
- Scales driver icon SVG from `viewBox="0 0 100 100"` to `viewBox="0 0 960 960"`
- Homey App Store guidelines require driver icons to use a 960x960 viewBox
- All coordinates scaled by 9.6x to maintain the same visual appearance

## Test plan
- [ ] Verify icon renders correctly in Homey
- [ ] Verify `homey app validate --level publish` passes