### PR TITLE
Improve app description tagline

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -12,9 +12,9 @@
     "de": "Valetudo"
   },
   "description": {
-    "en": "Control your Valetudo-powered robot vacuum",
-    "da": "Styr din Valetudo-drevne robotstøvsuger",
-    "de": "Steuere deinen Valetudo-betriebenen Saugroboter"
+    "en": "Smart multi-floor control for your Valetudo robot vacuum",
+    "da": "Smart multi-etage styring af din Valetudo robotstøvsuger",
+    "de": "Smarte Multi-Etagen-Steuerung für deinen Valetudo Saugroboter"
   },
   "category": [
     "appliances"


### PR DESCRIPTION
## Summary
- Updates app description from generic "Control your Valetudo-powered robot vacuum" to "Smart multi-floor control for your Valetudo robot vacuum"
- Highlights the app's key differentiator (multi-floor support)
- Updated in all three languages (en, da, de)

## Test plan
- [ ] Verify description reads well in the App Store listing
- [ ] Verify `homey app validate --level publish` passes