### PR TITLE
Fix driver icon invisible on blue background

### DIFF
--- a/drivers/valetudo/assets/icon.svg
+++ b/drivers/valetudo/assets/icon.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 960">
-  <circle cx="480" cy="480" r="432" fill="none" stroke="#000000" stroke-width="38.4"/>
-  <circle cx="480" cy="480" r="336" fill="none" stroke="#000000" stroke-width="19.2"/>
-  <circle cx="480" cy="365" r="57.6" fill="#000000"/>
-  <rect x="365" y="528" width="230.4" height="57.6" rx="28.8" fill="#000000"/>
-  <line x1="192" y1="480" x2="288" y2="480" stroke="#000000" stroke-width="19.2" stroke-linecap="round"/>
-  <line x1="672" y1="480" x2="768" y2="480" stroke="#000000" stroke-width="19.2" stroke-linecap="round"/>
+  <circle cx="480" cy="480" r="432" fill="none" stroke="#ffffff" stroke-width="38.4"/>
+  <circle cx="480" cy="480" r="336" fill="none" stroke="#ffffff" stroke-width="19.2"/>
+  <circle cx="480" cy="365" r="57.6" fill="#ffffff"/>
+  <rect x="365" y="528" width="230.4" height="57.6" rx="28.8" fill="#ffffff"/>
+  <line x1="192" y1="480" x2="288" y2="480" stroke="#ffffff" stroke-width="19.2" stroke-linecap="round"/>
+  <line x1="672" y1="480" x2="768" y2="480" stroke="#ffffff" stroke-width="19.2" stroke-linecap="round"/>
 </svg>


### PR DESCRIPTION
## Summary
- Change driver icon color from `#1a73e8` (blue) to `#ffffff` (white)
- Homey displays driver icons on the app's `brandColor` background (`#1a73e8` blue)
- White icon ensures visibility and matches the app view styling

## Test plan
- [ ] Verify driver icon displays as white on blue background in the brand/device overview