### PR TITLE
Fix new floor creation losing first floor's map

### DIFF
--- a/lib/FloorManager.js
+++ b/lib/FloorManager.js
@@ -202,6 +202,24 @@ class FloorManager {
     return { id, name };
   }
 
+  async createEmptyFloor(name, hasDock = true) {
+    const id = name.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/(^_|_$)/g, '');
+    if (!id) throw new Error('Invalid floor name');
+
+    const config = this._getStore();
+    const existing = config.floors.find((f) => f.id === id);
+    if (!existing) {
+      config.floors.push({ id, name, hasDock });
+    } else {
+      existing.hasDock = hasDock;
+    }
+    config.activeFloor = id;
+    await this._setStore(config);
+
+    this._log(`Floor "${name}" registered (no map yet — will be built by new map scan)`);
+    return { id, name };
+  }
+
   async isFloorSaved(floorId) {
     const floorDir = `${FLOORS_DIR}/${floorId}`;
     return this._ssh.fileExists(`${floorDir}/last_map`);
@@ -219,12 +237,14 @@ class FloorManager {
       return floor;
     }
 
-    // Step 1: Auto-save current floor if not yet backed up
+    // Step 1: Always save current floor's latest map before switching away
+    // (the backup may be stale from boot time or a previous session)
     if (config.activeFloor) {
-      const currentSaved = await this.isFloorSaved(config.activeFloor);
-      if (!currentSaved) {
-        this._log('Current floor has no backup, saving before switch...');
+      try {
+        this._log('Saving current floor map before switch...');
         await this.saveCurrentFloor(config.activeFloor);
+      } catch (err) {
+        this._log('Warning: could not backup current floor:', err.message);
       }
     }
 

--- a/widgets/vacuum-map/api.js
+++ b/widgets/vacuum-map/api.js
@@ -83,6 +83,13 @@ module.exports = {
     return { success: true };
   },
 
+  async setFloorDock({ homey, body }) {
+    const device = findDevice(homey, body.deviceId);
+    await device.floorManager.setFloorDock(body.floorId, body.hasDock === true);
+    device._updateFloorCapability();
+    return { success: true };
+  },
+
   async switchFloor({ homey, body }) {
     const device = findDevice(homey, body.deviceId);
     // Fire-and-forget — switching takes time (SSH + reboot)

--- a/widgets/vacuum-map/public/index.html
+++ b/widgets/vacuum-map/public/index.html
@@ -214,6 +214,23 @@
       border-color: rgba(255, 255, 255, 0.3);
       background: rgba(255, 255, 255, 0.08);
     }
+    .floor-item-dock {
+      background: none;
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 13px;
+      padding: 2px 6px;
+      opacity: 0.5;
+      transition: opacity 0.15s, border-color 0.15s;
+      flex-shrink: 0;
+      line-height: 1;
+    }
+    .floor-item-dock:hover { opacity: 0.8; }
+    .floor-item-dock.has-dock {
+      opacity: 1;
+      border-color: rgba(76, 175, 80, 0.6);
+    }
     .floor-item-delete {
       background: none;
       border: none;
@@ -506,6 +523,26 @@
           });
 
           item.appendChild(nameInput);
+
+          // Dock toggle button
+          var dockBtn = document.createElement('button');
+          dockBtn.className = 'floor-item-dock' + (f.hasDock ? ' has-dock' : '');
+          dockBtn.textContent = '\u2693'; // anchor symbol
+          dockBtn.title = f.hasDock ? 'Has dock (click to remove)' : 'No dock (click to add)';
+          dockBtn.addEventListener('click', function() {
+            var newVal = !f.hasDock;
+            _homey.api('POST', '/setFloorDock', { deviceId: deviceId, floorId: f.id, hasDock: newVal })
+              .then(function() {
+                f.hasDock = newVal;
+                dockBtn.className = 'floor-item-dock' + (newVal ? ' has-dock' : '');
+                dockBtn.title = newVal ? 'Has dock (click to remove)' : 'No dock (click to add)';
+                showToast((newVal ? 'Dock enabled' : 'Dock disabled') + ' for "' + f.name + '"', 'success');
+              })
+              .catch(function(err) {
+                showToast('Failed: ' + (err.message || String(err)), 'error');
+              });
+          });
+          item.appendChild(dockBtn);
 
           // Delete button
           var delBtn = document.createElement('button');

--- a/widgets/vacuum-map/widget.compose.json
+++ b/widgets/vacuum-map/widget.compose.json
@@ -37,6 +37,10 @@
       "method": "POST",
       "path": "/deleteFloor"
     },
+    "setFloorDock": {
+      "method": "POST",
+      "path": "/setFloorDock"
+    },
     "switchFloor": {
       "method": "POST",
       "path": "/switchFloor"


### PR DESCRIPTION
## Summary

- **Fixed: "New Floor" button was saving the current map under the wrong floor name**, causing the first floor's map to be lost. When pressing "New Floor" on Floor 1, the code saved Floor 1's map into Floor 2's backup directory, then destroyed it with `startNewMap()`. Switching back to Floor 1 would fail with "no saved map" (or load a stale map from boot time).
- **Fixed: `switchFloor` now always re-saves the current floor's latest map** before switching away, instead of only saving when no backup exists. This prevents stale backups from `_initFirstFloor` at boot time.
- **Added: Dock toggle in the widget's floor management overlay**, so users can set whether each floor has a dock directly from the map widget — previously this was only possible via flow cards.

## Root Cause

The `button_new_floor` handler had inverted semantics:

| Step | Before (broken) | After (fixed) |
|---|---|---|
| 1 | — | Backup active floor's map via `saveCurrentFloor()` |
| 2 | Save current map as Floor N+1 (wrong floor!) | Create empty floor entry via new `createEmptyFloor()` |
| 3 | `startNewMap()` destroys Floor 1's only copy | `startNewMap()` — Floor 1 is safely backed up |

## Changes

**`lib/FloorManager.js`**
- Added `createEmptyFloor(name, hasDock)` — registers a floor in the store without copying map files (since the new floor has no map yet)
- `switchFloor` step 1: always re-save current floor's map (not just when missing), wrapped in try-catch for floors with no map yet

**`drivers/valetudo/device.js`**
- Rewrote `button_new_floor` handler to backup the active floor first, then create an empty new floor, then start mapping
- `getFloorList()` now includes `hasDock` in the response for the widget

**`widgets/vacuum-map/`**
- Added `setFloorDock` API endpoint (`api.js`, `widget.compose.json`)
- Added dock toggle button (anchor icon) per floor in the management overlay (`index.html`)

## Test plan

- [ ] Create Floor 1 (let robot map), press "New Floor", verify Floor 1's map is preserved in `/mnt/data/rockrobo/floors/floor_1/`
- [ ] After mapping Floor 2, switch back to Floor 1 via picker — verify Floor 1's map loads correctly
- [ ] Switch back to Floor 2 — verify Floor 2's map loads correctly
- [ ] Open widget floor management overlay — verify dock toggle (anchor icon) appears per floor
- [ ] Toggle dock on/off for a floor — verify toast confirmation and that "Return to dock" respects the setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)