### PR TITLE
Add CONTEXT.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.homeybuild/
 .DS_Store
 *.log
+CONTEXT.md


### PR DESCRIPTION
## Summary

- Adds `CONTEXT.md` to `.gitignore` to keep the local development context file out of version control

🤖 Generated with [Claude Code](https://claude.com/claude-code)