### PR TITLE
Fix floor tabs always clickable and graceful missing snapshot

### DIFF
--- a/drivers/valetudo/device.js
+++ b/drivers/valetudo/device.js
@@ -925,7 +925,8 @@ class ValetudoDevice extends Homey.Device {
         id: f.id,
         name: f.name,
         hasDock: f.hasDock !== false,
-        hasCachedMap: !!this._mapSnapshots[f.id],
+        // All registered floors have verified map files on the robot
+        hasCachedMap: true,
       })),
       activeFloor: activeId,
     };

--- a/widgets/vacuum-map/api.js
+++ b/widgets/vacuum-map/api.js
@@ -63,12 +63,15 @@ module.exports = {
       return device._api.getMap();
     }
 
-    // Otherwise return cached snapshot
+    // Return cached snapshot if available
     const snapshot = device.getMapSnapshot(floorId);
-    if (!snapshot) {
-      throw new Error(`No cached map for floor "${floorId}"`);
+    if (snapshot) {
+      return snapshot;
     }
-    return snapshot;
+
+    // No in-memory snapshot — map files exist on robot but we can't render
+    // them without switching. Return null so the widget can show a message.
+    return null;
   },
 
   async renameFloor({ homey, body }) {

--- a/widgets/vacuum-map/public/index.html
+++ b/widgets/vacuum-map/public/index.html
@@ -687,8 +687,11 @@
       _homey.api('GET', url)
         .then(function(mapData) {
           if (!mapData) {
-            statusEl.textContent = 'No map data returned';
+            // Map files exist on robot but no cached preview available
+            statusEl.textContent = 'Switch robot to this floor to view the map';
             statusEl.style.display = 'block';
+            canvas.width = 0;
+            canvas.height = 0;
             return;
           }
           statusEl.style.display = 'none';


### PR DESCRIPTION
## Summary

- Floor tabs for non-active floors were disabled after app restart because `hasCachedMap` depended on in-memory snapshots (`_mapSnapshots`) that don't survive restarts
- All registered floors have verified map files on the robot (saved via SSH at creation time), so `hasCachedMap` is now always `true`
- When viewing a non-active floor with no in-memory cache, the API returns `null` instead of throwing, and the widget shows "Switch robot to this floor to view the map" instead of an error

## Test plan

- [ ] Add two floors, restart the app, verify both floor tabs are clickable
- [ ] Click a non-active floor tab — verify helpful message appears instead of error
- [ ] Click active floor tab — verify live map renders normally
- [ ] Switch robot to the other floor — verify map loads after switch completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)