### PR TITLE
Add connection check to widget and improve unavailable message

### DIFF
--- a/widgets/vacuum-map/api.js
+++ b/widgets/vacuum-map/api.js
@@ -45,6 +45,7 @@ module.exports = {
     const isActive = activeStates.includes(state);
     return {
       state,
+      available: device.getAvailable(),
       refreshInterval: isActive ? activeInterval : activeInterval * 5,
     };
   },

--- a/widgets/vacuum-map/public/index.html
+++ b/widgets/vacuum-map/public/index.html
@@ -26,6 +26,18 @@
       color: var(--homey-text-color, #aaa);
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
       font-size: 14px;
+      text-align: center;
+      line-height: 1.5;
+    }
+    #status .status-icon {
+      font-size: 32px;
+      display: block;
+      margin-bottom: 8px;
+    }
+    #status .status-hint {
+      font-size: 11px;
+      opacity: 0.6;
+      margin-top: 4px;
     }
 
     /* Floor bar */
@@ -325,6 +337,7 @@
     var toastTimer = null;
     var switchPollTimer = null;
     var isSwitching = false;
+    var robotAvailable = true;
 
     // --- Toast ---
     function showToast(message, type) {
@@ -611,17 +624,46 @@
       }
     }
 
+    // --- Connection Check ---
+    function showDisconnected() {
+      robotAvailable = false;
+      canvas.width = 0;
+      canvas.height = 0;
+      floorBarEl.style.display = 'none';
+      switchFloorBtn.style.display = 'none';
+      statusEl.innerHTML = '<span class="status-icon">&#x1F50C;</span>'
+        + 'Robot not reachable'
+        + '<span class="status-hint">Waiting for connection…</span>';
+      statusEl.style.display = 'block';
+    }
+
+    function showConnected() {
+      if (!robotAvailable) {
+        robotAvailable = true;
+        statusEl.style.display = 'none';
+        loadFloors();
+        fetchAndRender();
+      }
+    }
+
     function scheduleRefresh() {
       refreshTimer = setTimeout(function() {
-        fetchAndRender();
-        loadFloors();
-        // Check state to determine next refresh interval + auto-switch
+        // Check state first to determine connectivity + refresh interval
         _homey.api('GET', '/state?deviceId=' + encodeURIComponent(deviceId))
           .then(function(data) {
             currentRefreshMs = data.refreshInterval || 10000;
-            checkAutoSwitch(data.state);
+            if (data.available === false) {
+              showDisconnected();
+            } else {
+              showConnected();
+              fetchAndRender();
+              loadFloors();
+              checkAutoSwitch(data.state);
+            }
           })
-          .catch(function() {})
+          .catch(function() {
+            showDisconnected();
+          })
           .then(function() {
             scheduleRefresh();
           });
@@ -635,14 +677,20 @@
       var deviceIds = Homey.getDeviceIds();
       if (deviceIds && deviceIds.length > 0) {
         deviceId = deviceIds[0];
-        loadFloors();
-        fetchAndRender();
-        // Fetch initial refresh interval, then start adaptive refresh
+        // Check connectivity before loading anything
         _homey.api('GET', '/state?deviceId=' + encodeURIComponent(deviceId))
           .then(function(data) {
             currentRefreshMs = data.refreshInterval || 10000;
+            if (data.available === false) {
+              showDisconnected();
+            } else {
+              loadFloors();
+              fetchAndRender();
+            }
           })
-          .catch(function() {})
+          .catch(function() {
+            showDisconnected();
+          })
           .then(function() {
             scheduleRefresh();
           });


### PR DESCRIPTION
## Summary

- Widget now checks robot connectivity via `getState` before rendering map data
- When the robot is unavailable, the widget shows a "Robot not reachable" screen with a plug icon and "Waiting for connection..." hint
- Auto-recovers when the connection is restored (re-fetches floors and map)
- Device `setUnavailable` message now includes the robot's IP and classifies the error type (connection refused, timed out, host unreachable)
- MQTT connected/disconnected events are now logged, and `_restFailCount` is reset on MQTT reconnect

## Test plan

- [ ] Power off the robot — verify widget shows "Robot not reachable" with plug icon
- [ ] Verify Homey device card shows descriptive unavailable message with IP
- [ ] Power on the robot — verify widget auto-recovers and shows the map
- [ ] Check Homey logs for MQTT connected/disconnected messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)