### PR TITLE
Preserve existing robot map when connecting for the first time

### DIFF
--- a/drivers/valetudo/device.js
+++ b/drivers/valetudo/device.js
@@ -480,10 +480,19 @@ class ValetudoDevice extends Homey.Device {
     // Check if the floor already has a map backup on the robot
     try {
       const hasSaved = await this._floorManager.isFloorSaved(activeId);
-      if (!hasSaved) {
-        this.log('Attempting SSH floor backup for:', activeId);
+      if (hasSaved) {
+        this.log(`Floor "${activeId}" already has a map backup`);
+        return;
+      }
+
+      // Check if the robot has an existing map (last_map) that we can preserve
+      const robotHasMap = await this._ssh.fileExists('/mnt/data/rockrobo/last_map');
+      if (robotHasMap) {
+        this.log(`Robot has an existing map — preserving it as "${activeId}" backup`);
         await this._floorManager.saveCurrentFloor(activeId);
-        this.log('Floor backup saved successfully');
+        this.log('Existing map preserved as floor backup successfully');
+      } else {
+        this.log('Robot has no existing map to preserve');
       }
     } catch (err) {
       this.log('Floor backup skipped:', err.message);


### PR DESCRIPTION
## Summary

- When a new robot is connected, explicitly checks if it already has an existing map (`last_map`) on the filesystem
- If found, preserves it as Floor 1's backup via SSH before any other operations could overwrite it
- Adds clear logging about whether an existing map was found and preserved
- Prevents losing a usable map when pairing a robot that was already mapped

## Test plan

- [ ] Connect a robot that already has a map — verify log says "Robot has an existing map — preserving it..."
- [ ] Connect a robot with no map — verify log says "Robot has no existing map to preserve"
- [ ] After connecting, verify Floor 1 shows the robot's existing map in the widget
- [ ] Create a new floor — verify Floor 1's map is still preserved (backed up before reset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)