### PR TITLE
Add visual processing overlay during floor switch

### DIFF
--- a/widgets/vacuum-map/public/index.html
+++ b/widgets/vacuum-map/public/index.html
@@ -152,6 +152,42 @@
     #toast.success { background: rgba(76, 175, 80, 0.85); }
     #toast.error { background: rgba(244, 67, 54, 0.85); }
 
+    /* Switching overlay */
+    #switching-overlay {
+      position: absolute;
+      top: 0; left: 0; right: 0; bottom: 0;
+      background: rgba(0, 0, 0, 0.6);
+      backdrop-filter: blur(4px);
+      -webkit-backdrop-filter: blur(4px);
+      display: none;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      z-index: 15;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      color: var(--homey-text-color, #eee);
+    }
+    #switching-overlay.show { display: flex; }
+    .switching-spinner {
+      width: 32px;
+      height: 32px;
+      border: 3px solid rgba(255, 255, 255, 0.15);
+      border-top-color: #4caf50;
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+      margin-bottom: 12px;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    .switching-title {
+      font-size: 14px;
+      font-weight: 600;
+      margin-bottom: 4px;
+    }
+    .switching-step {
+      font-size: 11px;
+      opacity: 0.7;
+    }
+
     /* Floor management overlay */
     #floor-overlay {
       position: absolute;
@@ -290,6 +326,12 @@
 
   <div id="toast"></div>
 
+  <div id="switching-overlay">
+    <div class="switching-spinner"></div>
+    <div class="switching-title">Switching floor…</div>
+    <div class="switching-step" id="switching-step">Preparing…</div>
+  </div>
+
   <div id="floor-overlay">
     <div id="floor-panel">
       <h3>Manage Floors</h3>
@@ -314,6 +356,8 @@
     var toastEl = document.getElementById('toast');
     var floorOverlayEl = document.getElementById('floor-overlay');
     var floorListEl = document.getElementById('floor-list');
+    var switchingOverlayEl = document.getElementById('switching-overlay');
+    var switchingStepEl = document.getElementById('switching-step');
     var deviceId = null;
     var refreshTimer = null;
     var currentRefreshMs = 10000;
@@ -399,6 +443,20 @@
     }
 
     // --- Switch Floor ---
+    function showSwitchingOverlay(floorName) {
+      switchingOverlayEl.querySelector('.switching-title').textContent = 'Switching to ' + floorName + '…';
+      switchingStepEl.textContent = 'Preparing…';
+      switchingOverlayEl.classList.add('show');
+    }
+
+    function updateSwitchingStep(text) {
+      switchingStepEl.textContent = text;
+    }
+
+    function hideSwitchingOverlay() {
+      switchingOverlayEl.classList.remove('show');
+    }
+
     switchFloorBtn.addEventListener('click', function() {
       var floorId = selectedFloorId;
       if (!floorId || floorId === activeFloorId || isSwitching) return;
@@ -412,16 +470,28 @@
       switchFloorBtn.classList.add('switching');
       switchFloorBtn.textContent = 'Switching…';
       updateSwitchButton();
-      showToast('Switching to ' + floorName + '…', 'info');
+      showSwitchingOverlay(floorName);
 
       _homey.api('POST', '/switchFloor', { deviceId: deviceId, floorId: floorId })
         .then(function() {
+          updateSwitchingStep('Backing up current map…');
+
           // Poll for active floor change
           var attempts = 0;
           var maxAttempts = 40; // 2 min at 3s intervals
           if (switchPollTimer) clearInterval(switchPollTimer);
           switchPollTimer = setInterval(function() {
             attempts++;
+
+            // Update step text based on progress
+            if (attempts <= 3) {
+              updateSwitchingStep('Swapping map files…');
+            } else if (attempts <= 8) {
+              updateSwitchingStep('Rebooting robot…');
+            } else {
+              updateSwitchingStep('Waiting for robot to come back online…');
+            }
+
             _homey.api('GET', '/floors?deviceId=' + encodeURIComponent(deviceId))
               .then(function(data) {
                 if (data && data.activeFloor === floorId) {
@@ -430,6 +500,7 @@
                   isSwitching = false;
                   activeFloorId = floorId;
                   selectedFloorId = null;
+                  hideSwitchingOverlay();
                   showToast('Switched to ' + floorName, 'success');
                   switchFloorBtn.classList.remove('switching');
                   switchFloorBtn.textContent = 'Switch robot to this floor';
@@ -443,6 +514,7 @@
               clearInterval(switchPollTimer);
               switchPollTimer = null;
               isSwitching = false;
+              hideSwitchingOverlay();
               showToast('Floor switch timed out', 'error');
               switchFloorBtn.classList.remove('switching');
               switchFloorBtn.textContent = 'Switch robot to this floor';
@@ -452,6 +524,7 @@
         })
         .catch(function(err) {
           isSwitching = false;
+          hideSwitchingOverlay();
           switchFloorBtn.classList.remove('switching');
           switchFloorBtn.textContent = 'Switch robot to this floor';
           showToast('Switch failed: ' + (err.message || String(err)), 'error');


### PR DESCRIPTION
## Summary

- Adds a full-screen overlay with a green spinner during floor switching
- Step descriptions progress as the switch proceeds:
  - "Preparing…"
  - "Backing up current map…"
  - "Swapping map files…"
  - "Rebooting robot…"
  - "Waiting for robot to come back online…"
- Overlay auto-dismisses on success (with success toast) or timeout (with error toast)
- Prevents confusion about whether the process is running or stuck

## Test plan

- [ ] Click "Switch robot to this floor" — verify overlay appears with spinner
- [ ] Verify step text updates as the switch progresses
- [ ] Wait for switch to complete — verify overlay dismisses and success toast appears
- [ ] Verify map reloads with the new floor after switch completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)