### PR TITLE
Prevent floor switch while new map is still being built

### DIFF
--- a/widgets/vacuum-map/api.js
+++ b/widgets/vacuum-map/api.js
@@ -46,6 +46,7 @@ module.exports = {
     return {
       state,
       available: device.getAvailable(),
+      mapping: typeof device.isMappingNewFloor === 'function' ? device.isMappingNewFloor() : false,
       refreshInterval: isActive ? activeInterval : activeInterval * 5,
     };
   },

--- a/widgets/vacuum-map/public/index.html
+++ b/widgets/vacuum-map/public/index.html
@@ -382,6 +382,7 @@
     var switchPollTimer = null;
     var isSwitching = false;
     var robotAvailable = true;
+    var isMapping = false;
 
     // --- Toast ---
     function showToast(message, type) {
@@ -448,7 +449,7 @@
 
     function updateSwitchButton() {
       var viewingId = selectedFloorId || activeFloorId;
-      if (floorsData.length <= 1 || !viewingId || viewingId === activeFloorId || isSwitching) {
+      if (floorsData.length <= 1 || !viewingId || viewingId === activeFloorId || isSwitching || isMapping) {
         switchFloorBtn.style.display = 'none';
       } else {
         switchFloorBtn.style.display = 'block';
@@ -472,7 +473,7 @@
 
     switchFloorBtn.addEventListener('click', function() {
       var floorId = selectedFloorId;
-      if (!floorId || floorId === activeFloorId || isSwitching) return;
+      if (!floorId || floorId === activeFloorId || isSwitching || isMapping) return;
 
       var floorName = '';
       for (var i = 0; i < floorsData.length; i++) {
@@ -729,6 +730,15 @@
               showDisconnected();
             } else {
               showConnected();
+              var wasMapping = isMapping;
+              isMapping = !!data.mapping;
+              if (wasMapping !== isMapping) {
+                updateSwitchButton();
+                if (wasMapping && !isMapping) {
+                  showToast('New floor map finalized', 'success');
+                  loadFloors();
+                }
+              }
               fetchAndRender();
               loadFloors();
               checkAutoSwitch(data.state);


### PR DESCRIPTION
## Summary

- Blocks floor switching while a new floor is being mapped (`_pendingNewFloor` is set)
- **Device**: `switchFloor()` throws a clear error, `floor_picker` capability rejects with a warning
- **Widget API**: `getState` now includes `mapping: true/false` so the widget knows the state
- **Widget**: Hides the "Switch robot to this floor" button during mapping, shows a "New floor map finalized" toast when mapping completes
- Prevents the incomplete map (showing cleaning route instead of segments) from being swapped in during a floor switch

## Test plan

- [ ] Create a new floor — verify "Switch robot to this floor" button is hidden
- [ ] Try changing the floor picker while mapping — verify warning appears
- [ ] Wait for mapping to complete — verify "New floor map finalized" toast appears
- [ ] Verify switch button becomes visible again after mapping completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)