### PR TITLE
Wait for map segment finalization before saving new floor

### DIFF
--- a/drivers/valetudo/driver.settings.compose.json
+++ b/drivers/valetudo/driver.settings.compose.json
@@ -91,6 +91,27 @@
           { "id": "20", "label": { "en": "20 seconds", "da": "20 sekunder", "de": "20 Sekunden" } },
           { "id": "30", "label": { "en": "30 seconds", "da": "30 sekunder", "de": "30 Sekunden" } }
         ]
+      },
+      {
+        "id": "segment_wait_timeout",
+        "type": "dropdown",
+        "label": {
+          "en": "Map finalization timeout",
+          "da": "Kort-finaliseringstimeout",
+          "de": "Karten-Finalisierungs-Timeout"
+        },
+        "hint": {
+          "en": "After a new floor mapping finishes, the app waits for the robot firmware to split the map into room segments before saving. Increase this if your robot is slow to finalize maps.",
+          "da": "Efter en ny etagekortlægning venter appen på, at robottens firmware opdeler kortet i rumsegmenter, inden det gemmes. Øg denne værdi, hvis din robot er langsom til at færdiggøre kort.",
+          "de": "Nach einer neuen Etagenkartierung wartet die App, bis die Roboter-Firmware die Karte in Raumsegmente aufteilt, bevor sie gespeichert wird. Erhöhe diesen Wert, wenn dein Roboter langsam bei der Kartenfinalisierung ist."
+        },
+        "value": "300",
+        "values": [
+          { "id": "120", "label": { "en": "2 minutes", "da": "2 minutter", "de": "2 Minuten" } },
+          { "id": "300", "label": { "en": "5 minutes (default)", "da": "5 minutter (standard)", "de": "5 Minuten (Standard)" } },
+          { "id": "600", "label": { "en": "10 minutes", "da": "10 minutter", "de": "10 Minuten" } },
+          { "id": "900", "label": { "en": "15 minutes", "da": "15 minutter", "de": "15 Minuten" } }
+        ]
       }
     ]
   },

--- a/widgets/vacuum-map/api.js
+++ b/widgets/vacuum-map/api.js
@@ -47,6 +47,7 @@ module.exports = {
       state,
       available: device.getAvailable(),
       mapping: typeof device.isMappingNewFloor === 'function' ? device.isMappingNewFloor() : false,
+      waitingForSegments: !!device._waitingForSegments,
       refreshInterval: isActive ? activeInterval : activeInterval * 5,
     };
   },


### PR DESCRIPTION
## Summary

- After a mapping run finishes, the app now polls the Valetudo map API every 10s checking for segment layers in the map data before saving via SSH
- Previously the auto-save triggered immediately on state transition (cleaning→idle), saving the map before firmware had processed room segments
- The entire mapping→finalization→save lifecycle is uninterruptible: `startCleaning`, `cleanSegment`, floor switching, floor picker, and `button_new_floor` are all blocked while `_pendingNewFloor` is set
- Stop/pause/dock remain allowed as safety controls
- Segment wait timeout is configurable in device settings (default 5 min, options: 2/5/10/15 min)
- Widget API now exposes `waitingForSegments` flag in `getState` response

## How it works

1. Robot finishes mapping clean → transitions to idle/docked
2. `_autoSaveNewFloor()` starts polling `GET /api/v2/robot/state/map`
3. Checks each response for layers with `type: "segment"`
4. Once segments appear → saves floor via SSH
5. If timeout is reached → saves anyway (map works, just without room segments)

## Test plan

- [ ] Create a new floor → verify robot starts mapping
- [ ] After mapping finishes → verify warning shows "Waiting for map to finalize…"
- [ ] Verify segments are detected and floor is saved with segments
- [ ] Try starting a clean during finalization → verify it's blocked
- [ ] Try switching floors during finalization → verify it's blocked
- [ ] Try pressing "New Floor" again during finalization → verify it's blocked
- [ ] Verify stop/pause still work during finalization
- [ ] Test timeout by setting to 2 minutes on a large map
- [ ] Verify the timeout setting appears in device settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)