### PR TITLE
Add manual segment trigger for no-dock floors

### DIFF
--- a/drivers/valetudo/device.js
+++ b/drivers/valetudo/device.js
@@ -396,6 +396,18 @@ class ValetudoDevice extends Homey.Device {
     this.log(`Mapping run finished — waiting for firmware to finalize map with segments before saving "${name}"`);
     this.setWarning(`Waiting for "${name}" map to finalize…`).catch(this.error);
 
+    // For no-dock floors, firmware won't segment automatically (requires docking).
+    // Trigger segmentation manually via quirk API or config patch + reboot.
+    if (!hasDock) {
+      this.log('Floor has no dock — triggering manual segmentation...');
+      this.setWarning(`Triggering segmentation for "${name}"…`).catch(this.error);
+      try {
+        await this._floorManager.triggerSegmentation();
+      } catch (err) {
+        this.log('Manual segmentation trigger failed:', err.message);
+      }
+    }
+
     // Poll map API until segment layers appear (firmware processes segments after cleaning ends)
     const startTime = Date.now();
     let segmentsFound = false;

--- a/lib/FloorManager.js
+++ b/lib/FloorManager.js
@@ -411,6 +411,45 @@ class FloorManager {
     return false;
   }
 
+  // --- Segment trigger for no-dock floors ---
+  // After a mapping pass on a floor without a dock, the firmware won't
+  // segment the map automatically (segmentation is triggered by docking).
+  // We force it by: 1) trying the Valetudo quirk API, 2) falling back to
+  // setting ready_for_segment_map=1 in RoboController.cfg + reboot.
+
+  async triggerSegmentation() {
+    // Try the Valetudo quirk API first
+    try {
+      const quirks = await this._api.getQuirks();
+      const segmentQuirk = quirks.find(
+        (q) => q.title && q.title.toLowerCase().includes('segment'),
+      );
+      if (segmentQuirk) {
+        this._log(`Found segment quirk: "${segmentQuirk.title}", triggering...`);
+        await this._api.setQuirk(segmentQuirk.id, 'trigger');
+        this._log('Segment quirk triggered successfully');
+        await this._sleep(5000);
+        return;
+      }
+    } catch (err) {
+      this._log('Quirk-based segmentation failed:', err.message);
+    }
+
+    // Fallback: set ready_for_segment_map=1 and reboot
+    this._log('Falling back to config-based segmentation trigger...');
+    try {
+      let cfg = await this._ssh.readFile(ROBO_CFG);
+      cfg = cfg.replace(/ready_for_segment_map\s*=\s*\d+/, 'ready_for_segment_map = 1');
+      await this._ssh.writeFile(ROBO_CFG, cfg);
+      this._log('Set ready_for_segment_map = 1, rebooting...');
+      await this._ssh.reboot();
+      await this._waitForOnline();
+      this._log('Robot back online after segmentation reboot');
+    } catch (err) {
+      this._log('Config-based segmentation trigger failed:', err.message);
+    }
+  }
+
   async _stopIfCleaning() {
     try {
       const attrs = await this._api.getStateAttributes();

--- a/lib/ValetudoApi.js
+++ b/lib/ValetudoApi.js
@@ -227,6 +227,21 @@ class ValetudoApi {
     return data;
   }
 
+  // --- Quirks ---
+
+  async getQuirks() {
+    const { data } = await this._client.get('/api/v2/robot/capabilities/QuirksCapability');
+    return data;
+  }
+
+  async setQuirk(id, value) {
+    const { data } = await this._client.put(
+      '/api/v2/robot/capabilities/QuirksCapability',
+      { id, value },
+    );
+    return data;
+  }
+
   // --- Map ---
 
   async getMap() {


### PR DESCRIPTION
## Summary

- On floors without a charging dock, the Roborock firmware never triggers map segmentation automatically (it only segments after docking). This leaves the map as one unsegmented blob with no room definitions.
- After a mapping run finishes on a no-dock floor, automatically trigger segmentation: first via the Valetudo QuirksCapability API, then falling back to setting `ready_for_segment_map=1` in `RoboController.cfg` + reboot.
- Adds `getQuirks()` and `setQuirk()` methods to `ValetudoApi.js`.

## Test plan

- [ ] Create a new floor with "has dock" unchecked
- [ ] Run a mapping pass on the no-dock floor
- [ ] Verify that after the mapping run finishes, segmentation is triggered automatically
- [ ] Verify the map shows room segments after the trigger completes
- [ ] Verify floors with a dock still work normally (no extra trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)