### PR TITLE
Fix SSH reboot command path for Roborock BusyBox

### DIFF
--- a/lib/SshManager.js
+++ b/lib/SshManager.js
@@ -122,7 +122,7 @@ class SshManager {
 
   async reboot() {
     try {
-      await this.exec('reboot');
+      await this.exec('/sbin/reboot');
     } catch {
       // reboot closes the connection, which is expected
     }


### PR DESCRIPTION
## Summary

- The bare `reboot` command is not in PATH on Roborock S5 BusyBox, causing floor switches to fail at the reboot step.
- Changed to use the full path `/sbin/reboot`.

## Test plan

- [ ] Trigger a floor switch and verify the robot reboots successfully
- [ ] Verify the floor switch completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)