### PR TITLE
Add alarm_error boolean capability for Homey Insights

### DIFF
--- a/.homeycompose/capabilities/alarm_error.json
+++ b/.homeycompose/capabilities/alarm_error.json
@@ -1,0 +1,23 @@
+{
+  "type": "boolean",
+  "title": {
+    "en": "Error",
+    "da": "Fejl",
+    "de": "Fehler"
+  },
+  "getable": true,
+  "setable": false,
+  "uiComponent": "sensor",
+  "icon": "/assets/capabilities/error.svg",
+  "insights": true,
+  "insightsTitleTrue": {
+    "en": "Error active",
+    "da": "Fejl aktiv",
+    "de": "Fehler aktiv"
+  },
+  "insightsTitleFalse": {
+    "en": "No error",
+    "da": "Ingen fejl",
+    "de": "Kein Fehler"
+  }
+}

--- a/drivers/roborock-s5/driver.compose.json
+++ b/drivers/roborock-s5/driver.compose.json
@@ -19,6 +19,7 @@
     "alarm_battery",
     "current_floor",
     "vacuum_error",
+    "alarm_error",
     "measure_clean_area_last",
     "measure_clean_duration_last",
     "measure_clean_area_total",

--- a/drivers/valetudo/driver.compose.json
+++ b/drivers/valetudo/driver.compose.json
@@ -19,6 +19,7 @@
     "alarm_battery",
     "current_floor",
     "vacuum_error",
+    "alarm_error",
     "measure_clean_area_last",
     "measure_clean_duration_last",
     "measure_clean_area_total",

--- a/lib/ValetudoDevice.js
+++ b/lib/ValetudoDevice.js
@@ -311,10 +311,12 @@ class ValetudoDevice extends Homey.Device {
     this._mqtt.on('vacuum_error', (errorMsg) => {
       if (errorMsg && errorMsg !== 'none') {
         this.setCapabilityValue('vacuum_error', errorMsg).catch(this.error);
+        this.setCapabilityValue('alarm_error', true).catch(this.error);
         this._triggerError(errorMsg);
         this._classifyError(errorMsg);
       } else {
         this.setCapabilityValue('vacuum_error', '').catch(this.error);
+        this.setCapabilityValue('alarm_error', false).catch(this.error);
         this._dustbinTriggered = false;
       }
     });
@@ -363,6 +365,11 @@ class ValetudoDevice extends Homey.Device {
     // Update onoff based on state
     const isOn = state === 'cleaning' || state === 'returning' || state === 'moving';
     this.setCapabilityValue('onoff', isOn).catch(this.error);
+
+    // Clear error alarm when state is no longer error
+    if (state !== 'error') {
+      this.setCapabilityValue('alarm_error', false).catch(this.error);
+    }
 
     // Trigger flow cards for state transitions
     if (previous && previous !== state) {


### PR DESCRIPTION
## Summary
- Homey Insights only supports `number` and `boolean` types — the existing `vacuum_error` string capability was ignored
- Adds a new `alarm_error` boolean capability that tracks whether the robot has an active error
- Error events now show up in the Homey Insights timeline with "Error active" / "No error" labels
- The existing `vacuum_error` string sensor continues to display the error message on the device page

## Changes
- New `.homeycompose/capabilities/alarm_error.json` boolean capability with insights support
- `alarm_error` added to both `valetudo` and `roborock-s5` driver capability lists
- `ValetudoDevice.js`: sets `alarm_error` to `true` on MQTT error events, `false` when cleared or state leaves error