### PR TITLE
Fix widget not finding devices on Roborock S5 driver

### DIFF
--- a/widgets/vacuum-map/api.js
+++ b/widgets/vacuum-map/api.js
@@ -1,8 +1,17 @@
 'use strict';
 
 function findDevice(homey, deviceId) {
-  const driver = homey.drivers.getDriver('valetudo');
-  const devices = driver.getDevices();
+  const driverIds = ['valetudo', 'roborock-s5'];
+  const devices = [];
+
+  for (const driverId of driverIds) {
+    try {
+      const driver = homey.drivers.getDriver(driverId);
+      devices.push(...driver.getDevices());
+    } catch {
+      // Driver not installed or not ready
+    }
+  }
 
   let device = devices.find((d) => d.getData().id === deviceId);
   if (!device) {


### PR DESCRIPTION
## Summary
- The widget API's `findDevice()` only searched the `valetudo` driver for devices
- If the robot was paired with the `roborock-s5` driver, the widget showed "Robot not reachable — Waiting for connection…" even though the robot was online
- Fixed by searching across all app drivers (`valetudo` and `roborock-s5`)

## Changes
- `widgets/vacuum-map/api.js`: `findDevice()` now iterates over all driver IDs instead of hardcoding `valetudo`