### PR TITLE
v0.0.8

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -19,5 +19,8 @@
   },
   "0.0.7": {
     "en": "Fix map file handling, add no-dock segmentation trigger, fix SSH reboot path, add Roborock S5 driver"
+  },
+  "0.0.8": {
+    "en": "Add error alarm for Homey Insights, fix widget for multi-driver support"
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "name.fox.mads.valetudo",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "compatibility": ">=12.4.0",
   "sdk": 3,
   "platforms": [

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "name.fox.mads.valetudo",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "compatibility": ">=12.4.0",
   "sdk": 3,
   "platforms": [


### PR DESCRIPTION
## Changelog

- Add error alarm for Homey Insights
- Fix widget for multi-driver support

## PRs included

- #46 — Add alarm_error boolean capability for Homey Insights
- #47 — Fix widget not finding devices on Roborock S5 driver