### PR TITLE
Always trigger segmentation after mapping if segments don't appear

### DIFF
--- a/lib/ValetudoDevice.js
+++ b/lib/ValetudoDevice.js
@@ -396,21 +396,12 @@ class ValetudoDevice extends Homey.Device {
     this.log(`Mapping run finished — waiting for firmware to finalize map with segments before saving "${name}"`);
     this.setWarning(`Waiting for "${name}" map to finalize…`).catch(this.error);
 
-    // For no-dock floors, firmware won't segment automatically (requires docking).
-    // Trigger segmentation manually via quirk API or config patch + reboot.
-    if (!hasDock) {
-      this.log('Floor has no dock — triggering manual segmentation...');
-      this.setWarning(`Triggering segmentation for "${name}"…`).catch(this.error);
-      try {
-        await this._floorManager.triggerSegmentation();
-      } catch (err) {
-        this.log('Manual segmentation trigger failed:', err.message);
-      }
-    }
-
-    // Poll map API until segment layers appear (firmware processes segments after cleaning ends)
+    // Poll map API until segment layers appear (firmware may process segments after docking)
+    // If segments don't appear within the initial wait, trigger segmentation manually.
     const startTime = Date.now();
     let segmentsFound = false;
+    let segmentationTriggered = false;
+    const triggerAfterMs = 30000; // Trigger segmentation manually after 30s without segments
 
     while (Date.now() - startTime < timeoutMs) {
       await new Promise((resolve) => { this.homey.setTimeout(resolve, SEGMENT_POLL_INTERVAL_MS); });
@@ -420,6 +411,18 @@ class ValetudoDevice extends Homey.Device {
         this.log('Segment wait aborted — pending floor was cleared');
         this._waitingForSegments = false;
         return;
+      }
+
+      // If no segments appeared after initial wait, trigger segmentation manually
+      if (!segmentationTriggered && Date.now() - startTime >= triggerAfterMs) {
+        segmentationTriggered = true;
+        this.log('No segments after initial wait — triggering manual segmentation...');
+        this.setWarning(`Triggering segmentation for "${name}"…`).catch(this.error);
+        try {
+          await this._floorManager.triggerSegmentation();
+        } catch (err) {
+          this.log('Manual segmentation trigger failed:', err.message);
+        }
       }
 
       try {


### PR DESCRIPTION
## Summary
- Previously, manual segmentation was only triggered for no-dock floors
- The firmware doesn't always auto-segment even after docking
- Now waits 30s for segments to appear naturally, then triggers segmentation via the quirk API if needed — regardless of dock status

## Changes
- `lib/ValetudoDevice.js`: Moved segmentation trigger into the polling loop as a fallback after 30s without segments