### PR TITLE
Wait for Valetudo to load map after reboot before returning

### DIFF
--- a/lib/FloorManager.js
+++ b/lib/FloorManager.js
@@ -543,15 +543,38 @@ class FloorManager {
   }
 
   async _waitForOnline() {
+    // Phase 1: Wait for Valetudo HTTP server to respond
+    let online = false;
     for (let i = 0; i < MAX_POLL_ATTEMPTS; i++) {
       await this._sleep(POLL_INTERVAL_MS);
       const reachable = await this._api.isReachable();
       if (reachable) {
         this._log('Robot is back online');
-        return;
+        online = true;
+        break;
       }
     }
-    throw new Error('Robot did not come back online after reboot');
+    if (!online) {
+      throw new Error('Robot did not come back online after reboot');
+    }
+
+    // Phase 2: Wait for Valetudo to load the map (layers present)
+    // After reboot, Valetudo may serve an empty/default map until it processes the map files.
+    const mapWaitMs = 30000;
+    const mapStart = Date.now();
+    while (Date.now() - mapStart < mapWaitMs) {
+      try {
+        const mapData = await this._api.getMap();
+        if (mapData && mapData.layers && mapData.layers.length > 0) {
+          this._log('Map loaded by Valetudo after reboot');
+          return;
+        }
+      } catch {
+        // Map API not ready yet
+      }
+      await this._sleep(2000);
+    }
+    this._log('Warning: map may not be fully loaded yet (timed out waiting for layers)');
   }
 
   _sleep(ms) {


### PR DESCRIPTION
## Summary
- After a floor switch, the widget briefly showed the old/default map before displaying the correct one
- Root cause: `_waitForOnline()` only checked that Valetudo's HTTP server was reachable, but Valetudo hadn't finished loading the restored map files yet
- The widget (and `_cacheCurrentMap()`) would fetch the map too early, getting stale data

## Fix
- Added a second phase to `_waitForOnline()` that polls the map API until layers are present (up to 30s)
- This ensures the floor switch doesn't complete until Valetudo has fully loaded the new map