### PR TITLE
v0.1.0

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -25,5 +25,8 @@
   },
   "0.0.9": {
     "en": "Always trigger segmentation after mapping if segments don't appear"
+  },
+  "0.1.0": {
+    "en": "Add Roborock S5 driver, error alarm insights, widget multi-driver support, auto segmentation trigger, wait for map after reboot, Roborock S5 product images"
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "name.fox.mads.valetudo",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "compatibility": ">=12.4.0",
   "sdk": 3,
   "platforms": [

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "name.fox.mads.valetudo",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "compatibility": ">=12.4.0",
   "sdk": 3,
   "platforms": [


### PR DESCRIPTION
## Changelog

- Add Roborock S5 specific driver, mark generic Valetudo driver as experimental
- Add error alarm boolean capability for Homey Insights
- Fix widget not finding devices on Roborock S5 driver
- Always trigger segmentation after mapping if segments don't appear
- Wait for Valetudo to load map after reboot before returning
- Replace Roborock S5 driver images with actual product photo

## PRs included

- #43 — Add Roborock S5 driver
- #46 — Add alarm_error boolean capability for Homey Insights
- #47 — Fix widget for multi-driver support
- #49 — Always trigger segmentation after mapping
- #51 — Wait for map to load after reboot
- #52 — Roborock S5 product images