### PR TITLE
fix: fetch segments via REST on discovery

### DIFF
--- a/lib/ValetudoDevice.js
+++ b/lib/ValetudoDevice.js
@@ -149,6 +149,9 @@ class ValetudoDevice extends Homey.Device {
     await this._updateConsumables();
     await this._updateStatistics();
 
+    // Fetch segments so flow card autocompletes are populated immediately
+    await this._fetchAndCacheSegments();
+
     // Try SSH floor backup if first floor was registered without one
     await this._tryFloorBackup();
 
@@ -171,6 +174,7 @@ class ValetudoDevice extends Homey.Device {
     // Device may have gone offline, try to reconnect
     this.log('Discovery: last seen changed, attempting reconnect...');
     this._fetchInitialState().catch(this.error);
+    this._fetchAndCacheSegments().catch(this.error);
   }
 
   // Expose for driver flow card access
@@ -915,11 +919,27 @@ class ValetudoDevice extends Homey.Device {
     }
   }
 
+  async _fetchAndCacheSegments() {
+    try {
+      const segments = await this._api.getSegments();
+      if (Array.isArray(segments) && segments.length > 0) {
+        this._mqtt.seedSegments(segments);
+        this.log(`Fetched ${segments.length} segments via REST`);
+      }
+    } catch (err) {
+      // MapSegmentationCapability may not be supported on all robots
+      this.log('Segment fetch skipped:', err.message);
+    }
+  }
+
   async _triggerCleaningFinished() {
     this.driver._cleaningFinishedTrigger.trigger(this).catch(this.error);
 
     // Refresh statistics capabilities
     await this._updateStatistics();
+
+    // Refresh segments — Valetudo may have re-segmented the map after cleaning
+    await this._fetchAndCacheSegments();
   }
 
   async _updateStatistics() {

--- a/lib/ValetudoMqtt.js
+++ b/lib/ValetudoMqtt.js
@@ -160,6 +160,19 @@ class ValetudoMqtt extends EventEmitter {
     }
   }
 
+  // Seed segments from the REST API response when MQTT hasn't published them yet.
+  // The REST MapSegmentationCapability endpoint returns the same array format as the
+  // MQTT MapData/segments topic: [{ id, name }, ...]
+  seedSegments(segments) {
+    if (!Array.isArray(segments) || segments.length === 0) return;
+    const map = {};
+    for (const seg of segments) {
+      map[String(seg.id)] = seg.name || `Segment ${seg.id}`;
+    }
+    this._segments = map;
+    this.emit('segments', this._segments);
+  }
+
   _parseMapData(payload) {
     try {
       const data = JSON.parse(payload);


### PR DESCRIPTION
## Problem

Segments (room names) were invisible in flow card autocompletes on first connect and for users without MQTT configured. The segment cache was only populated when Valetudo published an MQTT `MapData/segments` message, which only happens on map changes — not on connection.

## Fix

Fetch segments from the REST API (`MapSegmentationCapability`) at three points:

- **On discovery** (`onDiscoveryAvailable`) — populates the cache immediately when the device is first found
- **On reconnect** (`onDiscoveryLastSeenChanged`) — repopulates after the robot goes offline and comes back
- **After cleaning finishes** (`_triggerCleaningFinished`) — refreshes in case Valetudo re-segmented the map during the clean

MQTT continues to keep the cache current when available. The REST fetch acts as an always-reliable baseline regardless of MQTT configuration.

Applies to both the Valetudo and Roborock S5 drivers.