### PR TITLE
feat: add refresh segments action and clear segments on floor switch

### DIFF
--- a/.homeycompose/flow/actions/refresh_segments.json
+++ b/.homeycompose/flow/actions/refresh_segments.json
@@ -1,0 +1,26 @@
+{
+  "id": "refresh_segments",
+  "title": {
+    "en": "Refresh room segments",
+    "da": "Opdater rumsegmenter",
+    "de": "Raumsegmente aktualisieren"
+  },
+  "titleFormatted": {
+    "en": "[[device]] Refresh room segments",
+    "da": "[[device]] Opdater rumsegmenter",
+    "de": "[[device]] Raumsegmente aktualisieren"
+  },
+  "hint": {
+    "en": "Fetches the current room segments from the robot. Use this if rooms are missing from other flow card autocomplete lists.",
+    "da": "Henter de aktuelle rumsegmenter fra robotten. Brug dette hvis rum mangler i andre flow-korts autofuldførelses-lister.",
+    "de": "Ruft die aktuellen Raumsegmente vom Roboter ab. Verwende dies, wenn Räume in Autovervollständigungslisten anderer Flow-Karten fehlen."
+  },
+  "platforms": ["local"],
+  "args": [
+    {
+      "name": "device",
+      "type": "device",
+      "filter": "capability=vacuum_state"
+    }
+  ]
+}

--- a/lib/ValetudoDevice.js
+++ b/lib/ValetudoDevice.js
@@ -776,8 +776,15 @@ class ValetudoDevice extends Homey.Device {
     this._updateFloorCapability();
     // Cache the new floor's map after switch
     await this._cacheCurrentMap();
+    // Clear stale segments from the previous floor — the new floor's segments will be
+    // fetched when the robot comes back online after reboot (onDiscoveryLastSeenChanged)
+    this._mqtt.clearSegments();
     this.driver._floorSwitchedTrigger.trigger(this, { floor_name: floor.name }).catch(this.error);
     return floor;
+  }
+
+  async refreshSegments() {
+    await this._fetchAndCacheSegments();
   }
 
   async saveFloor(name, hasDock = true) {

--- a/lib/ValetudoDriver.js
+++ b/lib/ValetudoDriver.js
@@ -218,6 +218,11 @@ class ValetudoDriver extends Homey.Driver {
       .registerRunListener(async (args) => {
         await args.device.installVoicePack(args.url, args.language);
       });
+
+    this.homey.flow.getActionCard('refresh_segments')
+      .registerRunListener(async (args) => {
+        await args.device.refreshSegments();
+      });
   }
 
   _getFloorAutocomplete(device, query) {

--- a/lib/ValetudoMqtt.js
+++ b/lib/ValetudoMqtt.js
@@ -173,6 +173,11 @@ class ValetudoMqtt extends EventEmitter {
     this.emit('segments', this._segments);
   }
 
+  // Clear the segment cache after a floor switch so stale room names don't appear
+  clearSegments() {
+    this._segments = {};
+  }
+
   _parseMapData(payload) {
     try {
       const data = JSON.parse(payload);


### PR DESCRIPTION
## Changes

### Refresh segments flow action
Adds a new **"Refresh room segments"** flow action card that lets users manually fetch the current room list from the robot. This is useful as a first step in flows that use segment-based actions, or when segments are missing from autocomplete lists.

### Clear segment cache on floor switch
When switching floors via SSH map swap, the previous floor's segments are now cleared from the cache immediately. Since the robot reboots during a floor switch, the new floor's segments will be fetched automatically when it comes back online (`onDiscoveryLastSeenChanged`). This prevents stale room names from the old floor appearing in autocompletes.