### PR TITLE
feat: auto-detect additional robot maps on connection

### DIFF
--- a/lib/FloorManager.js
+++ b/lib/FloorManager.js
@@ -577,6 +577,76 @@ class FloorManager {
     this._log('Warning: map may not be fully loaded yet (timed out waiting for layers)');
   }
 
+  async discoverAdditionalMaps() {
+    const result = [];
+    const config = this._getStore();
+
+    // Track already-imported firmware map filenames (e.g. 'user_map1') to avoid re-importing
+    const importedFirmwareMaps = new Set(
+      config.floors.filter((f) => f.sourceFirmwareMap).map((f) => f.sourceFirmwareMap),
+    );
+
+    // 1. Firmware multi-maps: user_map1, user_map2, ... (user_map0 = current active map — skip)
+    try {
+      const output = await this._ssh.exec(`ls -1 "${MAP_BASE}"/user_map* 2>/dev/null || true`);
+      for (const filePath of output.trim().split('\n').filter(Boolean)) {
+        const fileName = filePath.split('/').pop();
+        const match = fileName.match(/^user_map(\d+)$/);
+        if (!match) continue;
+        const index = parseInt(match[1], 10);
+        if (index === 0) continue; // active map — already Floor 1
+        if (importedFirmwareMaps.has(fileName)) continue; // already imported previously
+        result.push({ type: 'firmware', path: filePath, fileName, index });
+      }
+    } catch (err) {
+      this._log('Firmware map scan failed:', err.message);
+    }
+
+    // 2. Unregistered saved floor dirs (e.g. from a previous Homey reset)
+    const registeredIds = new Set(config.floors.map((f) => f.id));
+    try {
+      const output = await this._ssh.exec(`ls -1 "${FLOORS_DIR}" 2>/dev/null || true`);
+      for (const dir of output.trim().split('\n').filter(Boolean)) {
+        if (registeredIds.has(dir)) continue;
+        const hasMap = await this._ssh.fileExists(`${FLOORS_DIR}/${dir}/last_map`);
+        if (hasMap) result.push({ type: 'saved', path: `${FLOORS_DIR}/${dir}`, dirName: dir });
+      }
+    } catch (err) {
+      this._log('Saved floor directory scan failed:', err.message);
+    }
+
+    return result;
+  }
+
+  async importDiscoveredMap(id, name, mapInfo) {
+    const config = this._getStore();
+
+    if (mapInfo.type === 'saved') {
+      // Directory already on robot at correct path — just register it
+      if (!config.floors.find((f) => f.id === id)) {
+        config.floors.push({ id, name, hasDock: true });
+        await this._setStore(config);
+      }
+      this._log(`Registered existing floor directory "${id}" as "${name}"`);
+      return { id, name };
+    }
+
+    // firmware: create dir, copy user_mapN → last_map
+    const floorDir = `${FLOORS_DIR}/${id}`;
+    await this._ssh.exec(`mkdir -p "${floorDir}"`);
+    await this._ssh.copyFile(mapInfo.path, `${floorDir}/last_map`);
+
+    const verified = await this._ssh.fileExists(`${floorDir}/last_map`);
+    if (!verified) throw new Error(`Map import verification failed for "${name}"`);
+
+    if (!config.floors.find((f) => f.id === id)) {
+      config.floors.push({ id, name, hasDock: true, sourceFirmwareMap: mapInfo.fileName });
+      await this._setStore(config);
+    }
+    this._log(`Imported firmware map "${mapInfo.fileName}" as floor "${name}"`);
+    return { id, name };
+  }
+
   _sleep(ms) {
     return new Promise((resolve) => { setTimeout(resolve, ms); });
   }

--- a/lib/ValetudoDevice.js
+++ b/lib/ValetudoDevice.js
@@ -155,6 +155,9 @@ class ValetudoDevice extends Homey.Device {
     // Try SSH floor backup if first floor was registered without one
     await this._tryFloorBackup();
 
+    // Detect and import any additional maps stored on robot filesystem
+    await this._detectAndImportAdditionalFloors();
+
     // Cache current map snapshot for the active floor
     await this._cacheCurrentMap();
   }
@@ -628,6 +631,39 @@ class ValetudoDevice extends Homey.Device {
       }
     } catch (err) {
       this.log('Floor backup skipped:', err.message);
+    }
+  }
+
+  async _detectAndImportAdditionalFloors() {
+    try {
+      const discovered = await this._floorManager.discoverAdditionalMaps();
+      if (discovered.length === 0) return;
+
+      this.log(`Detected ${discovered.length} additional map(s) on robot`);
+      const existingFloors = this._floorManager.getFloors();
+      let nextNum = existingFloors.length + 1;
+
+      for (const mapInfo of discovered) {
+        let id, name;
+        if (mapInfo.type === 'saved') {
+          // Preserve original floor ID and reconstruct readable name from slug
+          id = mapInfo.dirName;
+          name = mapInfo.dirName.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+        } else {
+          id = `floor_${nextNum}`;
+          name = `Floor ${nextNum}`;
+          nextNum++;
+        }
+        try {
+          await this._floorManager.importDiscoveredMap(id, name, mapInfo);
+          this.log(`Auto-registered floor "${name}" (${id})`);
+        } catch (err) {
+          this.log(`Failed to import discovered floor "${name}": ${err.message}`);
+        }
+      }
+      this._updateFloorPicker();
+    } catch (err) {
+      this.log('Additional floor detection skipped:', err.message);
     }
   }
 


### PR DESCRIPTION
## Summary

- On `onDiscoveryAvailable()`, after the initial floor backup, the app now scans the robot filesystem and auto-imports any maps not yet registered in Homey
- **Firmware multi-maps** (`user_map1`, `user_map2`, …): copied to `floors/<id>/last_map` and registered as "Floor 2", "Floor 3", etc.
- **Unregistered saved floor dirs** (e.g. from a previous Homey reset): re-registered directly using the existing directory, with a human-readable name reconstructed from the slug
- `sourceFirmwareMap` stored on imported firmware floors prevents duplicate imports on reconnect

## New methods

| Method | File |
|--------|------|
| `discoverAdditionalMaps()` | `lib/FloorManager.js` |
| `importDiscoveredMap(id, name, mapInfo)` | `lib/FloorManager.js` |
| `_detectAndImportAdditionalFloors()` | `lib/ValetudoDevice.js` |

## Behaviour

| Scenario | Result |
|----------|--------|
| Robot has `user_map0` only | No change |
| Robot has `user_map0` + `user_map1` | "Floor 2" auto-created on first connect |
| Reconnect after floors already imported | `sourceFirmwareMap` check prevents duplicates |
| Robot has unregistered `floors/` dirs | Registered using existing dir name |

## Test plan

- [ ] SSH into robot and verify `user_map1` exists alongside `user_map0`
- [ ] Delete the device in Homey and re-pair (or clear `floor_config` store value)
- [ ] On reconnect: confirm Floor 1 + Floor 2 appear in the floor picker
- [ ] Switch to Floor 2 — robot should reboot and load the correct map
- [ ] Reconnect again — no duplicate floors should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)