### PR TITLE
Update Homey App Version to v0.1.5

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -40,5 +40,8 @@
   },
   "0.1.4": {
     "en": "Fix refresh segments flow action not appearing in the Homey UI due to app.json not being rebuilt after adding the compose file."
+  },
+  "0.1.5": {
+    "en": "Auto-detect additional maps stored on robot (user_map1, user_map2, etc.) and register as extra floors on connection. Fixed flow card device picker not showing devices. Added Refresh Rooms button on device card; segment room list now always fetched fresh from the robot."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "name.fox.mads.valetudo",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "compatibility": ">=12.4.0",
   "sdk": 3,
   "platforms": [

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "name.fox.mads.valetudo",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "compatibility": ">=12.4.0",
   "sdk": 3,
   "platforms": [


### PR DESCRIPTION
Bumps app version to v0.1.5 (patch).

## Changes since v0.1.4

- Auto-detect additional maps stored on robot (`user_map1`, `user_map2`, etc.) and register as extra floors on connection
- Fixed flow card device picker not showing devices (filter changed from custom capability to `driver_id`)
- Added Refresh Rooms button on device card; segment room list now always fetched fresh from the robot

🤖 Generated with [Claude Code](https://claude.com/claude-code)