### PR TITLE
fix: flow cards for Roborock S5 and add detect-floors/segments buttons

### DIFF
--- a/.homeycompose/capabilities/button_detect_floors.json
+++ b/.homeycompose/capabilities/button_detect_floors.json
@@ -1,0 +1,12 @@
+{
+  "type": "boolean",
+  "title": {
+    "en": "Detect Floors",
+    "da": "Registrer etager",
+    "de": "Etagen erkennen"
+  },
+  "getable": false,
+  "setable": true,
+  "uiComponent": "button",
+  "icon": "/assets/capabilities/floor.svg"
+}

--- a/.homeycompose/flow/actions/clean_segment.json
+++ b/.homeycompose/flow/actions/clean_segment.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     },
     {
       "type": "autocomplete",

--- a/.homeycompose/flow/actions/clean_zone.json
+++ b/.homeycompose/flow/actions/clean_zone.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     },
     {
       "type": "autocomplete",

--- a/.homeycompose/flow/actions/delete_zone.json
+++ b/.homeycompose/flow/actions/delete_zone.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     },
     {
       "type": "autocomplete",

--- a/.homeycompose/flow/actions/go_to_location.json
+++ b/.homeycompose/flow/actions/go_to_location.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     },
     {
       "type": "number",

--- a/.homeycompose/flow/actions/install_voice_pack.json
+++ b/.homeycompose/flow/actions/install_voice_pack.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     },
     {
       "type": "text",

--- a/.homeycompose/flow/actions/locate.json
+++ b/.homeycompose/flow/actions/locate.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     }
   ]
 }

--- a/.homeycompose/flow/actions/pause_cleaning.json
+++ b/.homeycompose/flow/actions/pause_cleaning.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     }
   ]
 }

--- a/.homeycompose/flow/actions/play_test_sound.json
+++ b/.homeycompose/flow/actions/play_test_sound.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     }
   ]
 }

--- a/.homeycompose/flow/actions/refresh_segments.json
+++ b/.homeycompose/flow/actions/refresh_segments.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     }
   ]
 }

--- a/.homeycompose/flow/actions/rename_segment.json
+++ b/.homeycompose/flow/actions/rename_segment.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     },
     {
       "type": "autocomplete",

--- a/.homeycompose/flow/actions/reset_consumable.json
+++ b/.homeycompose/flow/actions/reset_consumable.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     },
     {
       "type": "dropdown",

--- a/.homeycompose/flow/actions/return_to_dock.json
+++ b/.homeycompose/flow/actions/return_to_dock.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     }
   ]
 }

--- a/.homeycompose/flow/actions/save_floor.json
+++ b/.homeycompose/flow/actions/save_floor.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     },
     {
       "type": "text",

--- a/.homeycompose/flow/actions/save_zone.json
+++ b/.homeycompose/flow/actions/save_zone.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     },
     {
       "type": "text",

--- a/.homeycompose/flow/actions/set_carpet_mode.json
+++ b/.homeycompose/flow/actions/set_carpet_mode.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     },
     {
       "type": "dropdown",

--- a/.homeycompose/flow/actions/set_dnd.json
+++ b/.homeycompose/flow/actions/set_dnd.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     },
     {
       "type": "dropdown",

--- a/.homeycompose/flow/actions/set_fan_speed.json
+++ b/.homeycompose/flow/actions/set_fan_speed.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     },
     {
       "type": "dropdown",

--- a/.homeycompose/flow/actions/set_speaker_volume.json
+++ b/.homeycompose/flow/actions/set_speaker_volume.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     },
     {
       "type": "number",

--- a/.homeycompose/flow/actions/start_cleaning.json
+++ b/.homeycompose/flow/actions/start_cleaning.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     }
   ]
 }

--- a/.homeycompose/flow/actions/start_new_map.json
+++ b/.homeycompose/flow/actions/start_new_map.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     }
   ]
 }

--- a/.homeycompose/flow/actions/stop_cleaning.json
+++ b/.homeycompose/flow/actions/stop_cleaning.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     }
   ]
 }

--- a/.homeycompose/flow/actions/switch_floor.json
+++ b/.homeycompose/flow/actions/switch_floor.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     },
     {
       "type": "autocomplete",

--- a/.homeycompose/flow/actions/update_floor.json
+++ b/.homeycompose/flow/actions/update_floor.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     },
     {
       "type": "autocomplete",

--- a/.homeycompose/flow/conditions/has_dock.json
+++ b/.homeycompose/flow/conditions/has_dock.json
@@ -32,7 +32,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     }
   ]
 }

--- a/.homeycompose/flow/conditions/has_state.json
+++ b/.homeycompose/flow/conditions/has_state.json
@@ -32,7 +32,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     },
     {
       "type": "dropdown",

--- a/.homeycompose/flow/conditions/is_carpet_mode_enabled.json
+++ b/.homeycompose/flow/conditions/is_carpet_mode_enabled.json
@@ -32,7 +32,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     }
   ]
 }

--- a/.homeycompose/flow/conditions/is_dnd_enabled.json
+++ b/.homeycompose/flow/conditions/is_dnd_enabled.json
@@ -32,7 +32,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     }
   ]
 }

--- a/.homeycompose/flow/conditions/is_in_segment.json
+++ b/.homeycompose/flow/conditions/is_in_segment.json
@@ -32,7 +32,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     },
     {
       "type": "autocomplete",

--- a/.homeycompose/flow/conditions/is_on_carpet.json
+++ b/.homeycompose/flow/conditions/is_on_carpet.json
@@ -32,7 +32,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     }
   ]
 }

--- a/.homeycompose/flow/conditions/is_on_floor.json
+++ b/.homeycompose/flow/conditions/is_on_floor.json
@@ -32,7 +32,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     },
     {
       "type": "autocomplete",

--- a/.homeycompose/flow/triggers/cleaning_finished.json
+++ b/.homeycompose/flow/triggers/cleaning_finished.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     }
   ]
 }

--- a/.homeycompose/flow/triggers/cleaning_started.json
+++ b/.homeycompose/flow/triggers/cleaning_started.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     }
   ]
 }

--- a/.homeycompose/flow/triggers/consumable_depleted.json
+++ b/.homeycompose/flow/triggers/consumable_depleted.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     }
   ],
   "tokens": [

--- a/.homeycompose/flow/triggers/dustbin_full.json
+++ b/.homeycompose/flow/triggers/dustbin_full.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     }
   ]
 }

--- a/.homeycompose/flow/triggers/error_occurred.json
+++ b/.homeycompose/flow/triggers/error_occurred.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     }
   ],
   "tokens": [

--- a/.homeycompose/flow/triggers/floor_switched.json
+++ b/.homeycompose/flow/triggers/floor_switched.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     }
   ],
   "tokens": [

--- a/.homeycompose/flow/triggers/robot_stuck.json
+++ b/.homeycompose/flow/triggers/robot_stuck.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     }
   ],
   "tokens": [

--- a/.homeycompose/flow/triggers/segment_cleaning_finished.json
+++ b/.homeycompose/flow/triggers/segment_cleaning_finished.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     }
   ],
   "tokens": [

--- a/.homeycompose/flow/triggers/segment_cleaning_started.json
+++ b/.homeycompose/flow/triggers/segment_cleaning_started.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     }
   ],
   "tokens": [

--- a/.homeycompose/flow/triggers/update_available.json
+++ b/.homeycompose/flow/triggers/update_available.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     }
   ],
   "tokens": [

--- a/.homeycompose/flow/triggers/valetudo_updated.json
+++ b/.homeycompose/flow/triggers/valetudo_updated.json
@@ -22,7 +22,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=valetudo"
+      "filter": "driver_id=valetudo|driver_id=roborock-s5"
     }
   ],
   "tokens": [

--- a/app.json
+++ b/app.json
@@ -109,7 +109,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           }
         ]
       },
@@ -137,7 +137,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           }
         ]
       },
@@ -165,7 +165,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           }
         ],
         "tokens": [
@@ -237,7 +237,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           }
         ]
       },
@@ -265,7 +265,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           }
         ],
         "tokens": [
@@ -309,7 +309,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           }
         ],
         "tokens": [
@@ -353,7 +353,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           }
         ],
         "tokens": [
@@ -397,7 +397,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           }
         ],
         "tokens": [
@@ -455,7 +455,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           }
         ],
         "tokens": [
@@ -513,7 +513,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           }
         ],
         "tokens": [
@@ -557,7 +557,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           }
         ],
         "tokens": [
@@ -627,7 +627,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           }
         ]
       },
@@ -665,7 +665,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           },
           {
             "type": "dropdown",
@@ -778,7 +778,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           }
         ]
       },
@@ -816,7 +816,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           }
         ]
       },
@@ -854,7 +854,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           },
           {
             "type": "autocomplete",
@@ -906,7 +906,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           }
         ]
       },
@@ -944,7 +944,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           },
           {
             "type": "autocomplete",
@@ -988,7 +988,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           },
           {
             "type": "autocomplete",
@@ -1042,7 +1042,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           },
           {
             "type": "autocomplete",
@@ -1096,7 +1096,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           },
           {
             "type": "autocomplete",
@@ -1138,7 +1138,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           },
           {
             "type": "number",
@@ -1188,7 +1188,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           },
           {
             "type": "text",
@@ -1244,7 +1244,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           }
         ]
       },
@@ -1272,7 +1272,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           }
         ]
       },
@@ -1300,7 +1300,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           }
         ]
       },
@@ -1328,7 +1328,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           }
         ]
       },
@@ -1356,7 +1356,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           },
           {
             "type": "autocomplete",
@@ -1412,7 +1412,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           },
           {
             "type": "dropdown",
@@ -1491,7 +1491,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           }
         ]
       },
@@ -1519,7 +1519,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           },
           {
             "type": "text",
@@ -1588,7 +1588,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           },
           {
             "type": "text",
@@ -1674,7 +1674,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           },
           {
             "type": "dropdown",
@@ -1729,7 +1729,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           },
           {
             "type": "dropdown",
@@ -1784,7 +1784,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           },
           {
             "type": "dropdown",
@@ -1879,7 +1879,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           },
           {
             "type": "number",
@@ -1920,7 +1920,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           }
         ]
       },
@@ -1948,7 +1948,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           }
         ]
       },
@@ -1976,7 +1976,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           }
         ]
       },
@@ -2004,7 +2004,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           },
           {
             "type": "autocomplete",
@@ -2046,7 +2046,7 @@
           {
             "name": "device",
             "type": "device",
-            "filter": "driver_id=valetudo"
+            "filter": "driver_id=valetudo|driver_id=roborock-s5"
           },
           {
             "type": "autocomplete",
@@ -2341,6 +2341,8 @@
         "measure_clean_duration_total",
         "button_locate",
         "button_dock",
+        "button_refresh_segments",
+        "button_detect_floors",
         "floor_picker",
         "new_floor_has_dock",
         "button_new_floor"
@@ -2820,6 +2822,7 @@
         "button_locate",
         "button_dock",
         "button_refresh_segments",
+        "button_detect_floors",
         "floor_picker",
         "new_floor_has_dock",
         "button_new_floor"
@@ -3343,6 +3346,18 @@
         "da": "Ingen fejl",
         "de": "Kein Fehler"
       }
+    },
+    "button_detect_floors": {
+      "type": "boolean",
+      "title": {
+        "en": "Detect Floors",
+        "da": "Registrer etager",
+        "de": "Etagen erkennen"
+      },
+      "getable": false,
+      "setable": true,
+      "uiComponent": "button",
+      "icon": "/assets/capabilities/floor.svg"
     },
     "button_dock": {
       "type": "boolean",

--- a/drivers/roborock-s5/driver.compose.json
+++ b/drivers/roborock-s5/driver.compose.json
@@ -26,6 +26,8 @@
     "measure_clean_duration_total",
     "button_locate",
     "button_dock",
+    "button_refresh_segments",
+    "button_detect_floors",
     "floor_picker",
     "new_floor_has_dock",
     "button_new_floor"

--- a/drivers/valetudo/driver.compose.json
+++ b/drivers/valetudo/driver.compose.json
@@ -27,6 +27,7 @@
     "button_locate",
     "button_dock",
     "button_refresh_segments",
+    "button_detect_floors",
     "floor_picker",
     "new_floor_has_dock",
     "button_new_floor"

--- a/lib/ValetudoDevice.js
+++ b/lib/ValetudoDevice.js
@@ -180,6 +180,10 @@ class ValetudoDevice extends Homey.Device {
       await this.refreshSegments();
     });
 
+    this.registerCapabilityListener('button_detect_floors', async () => {
+      await this.detectFloors();
+    });
+
     this.registerCapabilityListener('new_floor_has_dock', async (value) => {
       // Just stores the value — read by button_new_floor when pressed
       this.log(`New floor dock toggle set to: ${value}`);
@@ -796,6 +800,22 @@ class ValetudoDevice extends Homey.Device {
 
   async refreshSegments() {
     await this._fetchAndCacheSegments();
+  }
+
+  async detectFloors() {
+    this.setWarning('Detecting floors…').catch(this.error);
+    try {
+      await this._tryFloorBackup();
+      await this._detectAndImportAdditionalFloors();
+      this._updateFloorPicker();
+      this.unsetWarning().catch(this.error);
+      this.log('Floor detection complete');
+    } catch (err) {
+      this.log('Floor detection failed:', err.message);
+      const msg = this._sshErrorMessage(err);
+      this.setWarning(msg).catch(this.error);
+      this.homey.setTimeout(() => this.unsetWarning().catch(this.error), 15000);
+    }
   }
 
   async getSegments() {


### PR DESCRIPTION
## Summary

- **Fix Roborock S5 flow cards**: All 41 flow card filters updated from `driver_id=valetudo` to `driver_id=valetudo|driver_id=roborock-s5` — flow cards now appear for both drivers
- **Add "Detect Floors" button**: New `button_detect_floors` device card button that SSH-scans the robot filesystem and auto-registers any unregistered maps/floors. Needed because SSH credentials may not be configured at discovery time
- **Add "Refresh Rooms" button to Roborock S5**: `button_refresh_segments` was already on the valetudo driver; now added to roborock-s5 as well

## Details

### Flow card fix
The app-level flow cards all had `"filter": "driver_id=valetudo"` which excluded roborock-s5 devices entirely. Fixed with a batch update across all 41 flow definition files.

### Detect Floors button
- New capability: `button_detect_floors` (boolean, setable, uiComponent: button)
- When pressed: runs `_tryFloorBackup()` + `_detectAndImportAdditionalFloors()` and updates the floor picker
- Shows "Detecting floors…" warning while running; shows SSH error message (with 15s auto-clear) on failure
- Added to both `valetudo` and `roborock-s5` drivers

## Test plan

- [ ] Add a Roborock S5 device and verify flow cards appear in Homey flows
- [ ] Confirm valetudo driver flow cards still appear
- [ ] Press "Detect Floors" button on device card — verify it scans robot and adds any unregistered floors
- [ ] Press "Detect Floors" without SSH configured — verify warning appears and clears after 15s
- [ ] Press "Refresh Rooms" on Roborock S5 — verify rooms update

🤖 Generated with [Claude Code](https://claude.com/claude-code)