### PR TITLE
v0.1.7 — widget floor switch and map preview fixes

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -46,5 +46,8 @@
   },
   "0.1.6": {
     "en": "Fix flow cards not appearing for Roborock S5 devices, add Detect Floors button to scan robot filesystem for unregistered maps, add Refresh Rooms button to Roborock S5 device card"
+  },
+  "0.1.7": {
+    "en": "Fix widget floor switch blocked during mapping now errors immediately instead of timing out, fix widget showing robot default map for newly detected floors, make detected floor tabs clickable to reveal the switch button"
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "name.fox.mads.valetudo",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "compatibility": ">=12.4.0",
   "sdk": 3,
   "platforms": [

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "name.fox.mads.valetudo",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "compatibility": ">=12.4.0",
   "sdk": 3,
   "platforms": [


### PR DESCRIPTION
## Summary

- Floor switch blocked by in-progress mapping now returns an error immediately from the widget API instead of silently timing out after 2 minutes
- Widget no longer shows the robot's default/live map when a newly detected floor has no cached preview — instead correctly shows the grayed-out tab state and "Switch to this floor" message
- Newly detected (no-snapshot) floor tabs are now clickable — clicking reveals the switch button so the user can activate the floor directly from the widget
- `detectFloors()` now refreshes the active floor's map snapshot after importing, keeping the widget preview current

## Test plan

- [ ] Press "Detect Floors" while a new floor mapping run is in progress — widget should show an error immediately
- [ ] Press "Detect Floors" with SSH configured — newly detected floors appear as slightly dimmed tabs in the widget
- [ ] Click a dimmed (no-snapshot) floor tab — "Switch robot to this floor" message + switch button appears
- [ ] Active floor map in widget refreshes after detect floors completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)