### PR TITLE
Bump version to v0.1.8

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -49,5 +49,8 @@
   },
   "0.1.7": {
     "en": "Fix widget floor switch blocked during mapping now errors immediately instead of timing out, fix widget showing robot default map for newly detected floors, make detected floor tabs clickable to reveal the switch button"
+  },
+  "0.1.8": {
+    "en": "Fix S5 flow card device filters, improve floor switching reliability (segment positioning, PersistData backup/restore), and persist map snapshots across Homey restarts"
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "name.fox.mads.valetudo",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "compatibility": ">=12.4.0",
   "sdk": 3,
   "platforms": [

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "name.fox.mads.valetudo",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "compatibility": ">=12.4.0",
   "sdk": 3,
   "platforms": [


### PR DESCRIPTION
## Version bump: 0.1.7 → 0.1.8

Patch release following [#75](https://github.com/MadsSFox/name.fox.mads.valetudo/pull/75).

### What's in this release
- **S5 compatibility** — Fixed malformed device filter on all 41 flow cards so they appear correctly for Roborock S5 users
- **Reliable floor switching** — Segments now load in the correct position after a floor switch (waits for SLAM to stabilise, backs up all PersistData files, prevents empty robot.db backups)
- **Map snapshots survive restarts** — Non-active floor maps are now persisted to device store and restored on Homey restart, so the widget can show cached maps without switching the robot

🤖 Generated with [Claude Code](https://claude.ai/claude-code)