### PR TITLE
Fix: don't overwrite floor map snapshot while robot is cleaning

### DIFF
--- a/lib/ValetudoDevice.js
+++ b/lib/ValetudoDevice.js
@@ -1178,6 +1178,13 @@ class ValetudoDevice extends Homey.Device {
     try {
       const activeId = this._floorManager.getActiveFloor();
       if (!activeId) return;
+      // Only snapshot when the robot is settled — mid-clean maps have path trails
+      // and incomplete segment data that would overwrite the good stored snapshot.
+      const state = this.getCapabilityValue('vacuum_state') || 'idle';
+      if (state === 'cleaning' || state === 'returning' || state === 'moving') {
+        this.log(`Skipping map snapshot while robot is ${state}`);
+        return;
+      }
       const mapData = await this._api.getMap();
       this._mapSnapshots[activeId] = mapData;
       this.log(`Cached map snapshot for ${activeId}`);


### PR DESCRIPTION
## What's changed

When the Homey app restarted or reconnected (e.g. after an app update) while the robot was mid-clean, `_cacheCurrentMap` would immediately snapshot the live map — which at that point contained path trails from the current clean and incomplete segment data — and persist it to the store. This overwrote the good floor map that was previously saved.

**Now map snapshots are only captured when the robot is in a settled state** (docked, idle, paused, or error). Cleaning, returning, and moving states are skipped. The snapshot updates naturally once the robot docks after finishing a clean.

## Test plan
- [x] 197 unit tests passing
- [ ] Reconnect app while robot is cleaning — confirm floor map snapshot is not overwritten
- [ ] Robot finishes clean and docks — confirm snapshot updates correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)