### PR TITLE
Bump version to v0.1.10

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -55,5 +55,8 @@
   },
   "0.1.9": {
     "en": "Floor deletion now fails safely if the robot is unreachable — the floor stays visible in the widget instead of being silently removed"
+  },
+  "0.1.10": {
+    "en": "Fix: map snapshots are no longer overwritten while the robot is cleaning — the widget now always shows the last complete floor map"
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "name.fox.mads.valetudo",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "compatibility": ">=12.4.0",
   "sdk": 3,
   "platforms": [

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "name.fox.mads.valetudo",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "compatibility": ">=12.4.0",
   "sdk": 3,
   "platforms": [


### PR DESCRIPTION
## Version bump: 0.1.9 → 0.1.10

Patch release.

### What's in this release
- **Map snapshot guard** — The widget no longer overwrites the stored floor map with an in-progress cleaning map when the app reconnects while the robot is cleaning. Snapshots are now only captured when the robot is docked, idle, or paused.
- **Safe floor deletion** — Deleting a floor now fails if SSH to the robot fails, keeping the floor visible in the widget rather than silently removing it.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)