### PR TITLE
Fix: recreate user_map0 after floor switch to prevent map rebuild

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -58,5 +58,8 @@
   },
   "0.1.10": {
     "en": "Fix: map snapshots are no longer overwritten while the robot is cleaning — the widget now always shows the last complete floor map"
+  },
+  "0.1.11": {
+    "en": "Fix: floor switches no longer cause planned cleans to rebuild the map — user_map0 is now recreated after every floor restore"
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "name.fox.mads.valetudo",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "compatibility": ">=12.4.0",
   "sdk": 3,
   "platforms": [

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "name.fox.mads.valetudo",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "compatibility": ">=12.4.0",
   "sdk": 3,
   "platforms": [

--- a/lib/FloorManager.js
+++ b/lib/FloorManager.js
@@ -370,6 +370,16 @@ class FloorManager {
     const floorDir = `${FLOORS_DIR}/${floorId}`;
     await this._restoreMapFiles(floorDir);
 
+    // Step 7.5: Recreate user_map0 from last_map so the firmware has its
+    // primary map slot populated. Without this, scheduled/planned cleans
+    // find no user_map0 and trigger a full map rebuild.
+    try {
+      await this._ssh.exec(`cp "${MAP_BASE}/last_map" "${MAP_BASE}/user_map0"`);
+      this._log('  Recreated user_map0 from last_map');
+    } catch (err) {
+      this._log('Warning: could not recreate user_map0:', err.message);
+    }
+
     // Step 8: Patch RoboController.cfg
     this._log('Patching RoboController.cfg...');
     await this._patchConfig();


### PR DESCRIPTION
## Problem

After switching floors, the robot would sometimes start a full map rebuild on the next planned/scheduled clean instead of using the existing map.

**Root cause:** `user_map0` is the firmware's primary map slot — it uses this file when running scheduled cleans. It's correctly removed before a floor switch (to prevent stale data from interfering), but was never recreated after the new floor's files were restored.

With `user_map0` missing, the firmware found no map on the next scheduled clean and started rebuilding from scratch.

## Fix

After restoring the target floor's map files, `last_map` is copied to `user_map0` so the firmware finds its expected map slot populated and uses the restored map instead of rebuilding.

## Test plan
- [x] 197 unit tests passing
- [ ] Switch floors and run a planned clean on the restored floor — confirm it uses the existing map instead of rebuilding

🤖 Generated with [Claude Code](https://claude.ai/claude-code)