### PR TITLE
Fix: app crash when MQTT broker rejects connection

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -61,5 +61,8 @@
   },
   "0.1.11": {
     "en": "Fix: floor switches no longer cause planned cleans to rebuild the map — user_map0 is now recreated after every floor restore"
+  },
+  "0.1.12": {
+    "en": "Fix: app no longer crashes when the MQTT broker rejects the connection — wrong credentials, self-signed certificates, and other broker errors are now handled gracefully"
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "name.fox.mads.valetudo",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "compatibility": ">=12.4.0",
   "sdk": 3,
   "platforms": [

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "name.fox.mads.valetudo",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "compatibility": ">=12.4.0",
   "sdk": 3,
   "platforms": [

--- a/lib/ValetudoMqtt.js
+++ b/lib/ValetudoMqtt.js
@@ -72,7 +72,11 @@ class ValetudoMqtt extends EventEmitter {
 
     this._client.on('error', (err) => {
       this._log('MQTT error:', err.message);
-      this.emit('error', err);
+      // Do NOT emit('error') — unhandled 'error' events crash Node.js.
+      // Treat broker errors (auth failure, connection refused, etc.) as a
+      // disconnect so the app falls back to REST polling gracefully.
+      this._connected = false;
+      this.emit('disconnected');
     });
 
     this._client.on('close', () => {


### PR DESCRIPTION
## Problem

The app crashed immediately after saving MQTT broker settings if the broker rejected the connection — for example due to wrong credentials, a self-signed certificate, or a refused connection.

**Root cause:** `ValetudoMqtt` was re-emitting the mqtt client's `error` event directly. In Node.js, emitting an `error` event on an `EventEmitter` with no listener attached crashes the entire process. Since nothing in the device code listened for `error` events on the MQTT client, any broker error caused a hard crash.

Known crash variants:
- `Connection refused: Not authorized` — wrong username/password
- `self-signed certificate` — broker using a self-signed TLS cert
- Any other broker-level connection error

## Fix

Instead of re-emitting `error`, broker errors are now treated as a disconnect — the connection state is cleared and a `disconnected` event is emitted. The app then falls back to REST polling as normal, and will retry MQTT on the next reconnect cycle.

## Test plan
- [x] 197 unit tests passing
- [ ] Configure MQTT with wrong credentials — confirm app stays running and falls back to REST polling
- [ ] Configure MQTT with a self-signed cert — confirm no crash

🤖 Generated with [Claude Code](https://claude.ai/claude-code)