### PR TITLE
Merge error capabilities into single alarm_error with dynamic message

### DIFF
--- a/drivers/roborock-s5/driver.compose.json
+++ b/drivers/roborock-s5/driver.compose.json
@@ -18,7 +18,6 @@
     "measure_battery",
     "alarm_battery",
     "current_floor",
-    "vacuum_error",
     "alarm_error",
     "measure_clean_area_last",
     "measure_clean_duration_last",

--- a/drivers/valetudo/driver.compose.json
+++ b/drivers/valetudo/driver.compose.json
@@ -18,7 +18,6 @@
     "measure_battery",
     "alarm_battery",
     "current_floor",
-    "vacuum_error",
     "alarm_error",
     "measure_clean_area_last",
     "measure_clean_duration_last",

--- a/lib/ValetudoDevice.js
+++ b/lib/ValetudoDevice.js
@@ -46,9 +46,6 @@ class ValetudoDevice extends Homey.Device {
     if (this.getCapabilityValue('new_floor_has_dock') === null) {
       this.setCapabilityValue('new_floor_has_dock', true).catch(this.error);
     }
-    if (!this.getCapabilityValue('vacuum_error')) {
-      this.setCapabilityValue('vacuum_error', '-').catch(this.error);
-    }
 
     this._startPolling();
     this.log('ValetudoDevice initialized (waiting for discovery...)');
@@ -347,13 +344,13 @@ class ValetudoDevice extends Homey.Device {
 
     this._mqtt.on('vacuum_error', (errorMsg) => {
       if (errorMsg && errorMsg !== 'none') {
-        this.setCapabilityValue('vacuum_error', errorMsg).catch(this.error);
         this.setCapabilityValue('alarm_error', true).catch(this.error);
+        this.setCapabilityOptions('alarm_error', { title: { en: errorMsg, da: errorMsg, de: errorMsg } }).catch(this.error);
         this._triggerError(errorMsg);
         this._classifyError(errorMsg);
       } else {
-        this.setCapabilityValue('vacuum_error', '-').catch(this.error);
         this.setCapabilityValue('alarm_error', false).catch(this.error);
+        this.setCapabilityOptions('alarm_error', { title: { en: 'Error', da: 'Fejl', de: 'Fehler' } }).catch(this.error);
         this._dustbinTriggered = false;
       }
     });


### PR DESCRIPTION
## Summary

- Removes the separate `vacuum_error` string capability from the device stats
- The `alarm_error` capability now shows the error message directly in its title via `setCapabilityOptions()` when an error is active
- When no error: title resets to "Error" (inactive alarm, no visual clutter)
- When error occurs: title updates to the actual message (e.g. "Stuck near cliff"), alarm turns red
- Flow triggering is unchanged — `error_occurred` trigger card still fires with the `error_message` token

## Result
Single row in device stats instead of two. Shows the error description inline when active, acts as a standard Homey alarm for flows.

## Test plan
- [ ] Trigger a robot error and verify the alarm_error capability title updates to the error message
- [ ] Verify error clears and title resets to "Error"
- [ ] Verify `error_occurred` flow trigger still fires with the correct `error_message` token

🤖 Generated with [Claude Code](https://claude.com/claude-code)