### PR TITLE
fix: correct broken GitHub repo links

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -76,10 +76,10 @@
       "multi-etage"
     ]
   },
-  "source": "https://github.com/MadsSFox/homey-valetudo",
-  "homepage": "https://github.com/MadsSFox/homey-valetudo",
-  "support": "https://github.com/MadsSFox/homey-valetudo/issues",
+  "source": "https://github.com/MadsSFox/name.fox.mads.valetudo",
+  "homepage": "https://github.com/MadsSFox/name.fox.mads.valetudo",
+  "support": "https://github.com/MadsSFox/name.fox.mads.valetudo/issues",
   "bugs": {
-    "url": "https://github.com/MadsSFox/homey-valetudo/issues"
+    "url": "https://github.com/MadsSFox/name.fox.mads.valetudo/issues"
   }
 }

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement via [GitHub Issues](https://github.com/MadsSFox/homey-valetudo/issues). All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement via [GitHub Issues](https://github.com/MadsSFox/name.fox.mads.valetudo/issues). All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Thanks to [Mark Haehnel](https://github.com/markhaehnel) for the **[original hom
 
 ## Source Code
 
-[GitHub Repository](https://github.com/MadsSFox/homey-valetudo)
+[GitHub Repository](https://github.com/MadsSFox/name.fox.mads.valetudo)
 
 ## License
 

--- a/app.json
+++ b/app.json
@@ -77,11 +77,11 @@
       "multi-etage"
     ]
   },
-  "source": "https://github.com/MadsSFox/homey-valetudo",
-  "homepage": "https://github.com/MadsSFox/homey-valetudo",
-  "support": "https://github.com/MadsSFox/homey-valetudo/issues",
+  "source": "https://github.com/MadsSFox/name.fox.mads.valetudo",
+  "homepage": "https://github.com/MadsSFox/name.fox.mads.valetudo",
+  "support": "https://github.com/MadsSFox/name.fox.mads.valetudo/issues",
   "bugs": {
-    "url": "https://github.com/MadsSFox/homey-valetudo/issues"
+    "url": "https://github.com/MadsSFox/name.fox.mads.valetudo/issues"
   },
   "flow": {
     "triggers": [


### PR DESCRIPTION
## Summary
- All links pointing to `MadsSFox/homey-valetudo` (old/wrong repo name) updated to `MadsSFox/name.fox.mads.valetudo`
- Affected files: `app.json`, `.homeycompose/app.json`, `README.md`, `CODE_OF_CONDUCT.md`

Closes #81

## Test plan
- [x] Verify links in `app.json` and `.homeycompose/app.json` (`source`, `homepage`, `support`, `bugs.url`) resolve correctly
- [x] Verify README source code link resolves correctly
- [x] Verify Code of Conduct enforcement link resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)