### PR TITLE
feat: MapSnapshotCapability REST fallback for floor switching

### DIFF
--- a/lib/FloorManager.js
+++ b/lib/FloorManager.js
@@ -317,6 +317,16 @@ class FloorManager {
       return floor;
     }
 
+    // Snapshot-only floors: skip SSH entirely and restore via REST API
+    if (floor.snapshotId && !floor.sshBacked) {
+      this._log(`Floor "${floor.name}" uses snapshot-based switching`);
+      await this._switchFloorViaSnapshot(floor);
+      config.activeFloor = floorId;
+      await this._setStore(config);
+      this._log(`Switched to floor "${floor.name}" via snapshot`);
+      return floor;
+    }
+
     // Step 1: Always save current floor's latest map before switching away
     // (the backup may be stale from boot time or a previous session)
     if (config.activeFloor) {
@@ -338,6 +348,15 @@ class FloorManager {
     }
 
     if (!saved) {
+      // Last resort: if this floor has a snapshot ID, use the REST API
+      if (floor.snapshotId) {
+        this._log(`No SSH map found for "${floor.name}", falling back to snapshot restore`);
+        await this._switchFloorViaSnapshot(floor);
+        config.activeFloor = floorId;
+        await this._setStore(config);
+        this._log(`Switched to floor "${floor.name}" via snapshot fallback`);
+        return floor;
+      }
       throw new Error(`No saved map for "${floor.name}". Navigate robot to that floor and use "New Floor" to save it.`);
     }
 
@@ -398,6 +417,14 @@ class FloorManager {
 
     this._log(`Switched to floor "${floor.name}" successfully`);
     return floor;
+  }
+
+  async _switchFloorViaSnapshot(floor) {
+    this._log(`Restoring snapshot "${floor.snapshotId}" for floor "${floor.name}"...`);
+    await this._stopIfCleaning();
+    await this._api.restoreMapSnapshot(floor.snapshotId);
+    this._log('Snapshot restore requested, waiting for map to load...');
+    await this._waitForOnline();
   }
 
   async _tryRecoverFloorMap(floorId, floorName) {
@@ -635,6 +662,18 @@ class FloorManager {
       this._log('Saved floor directory scan failed:', err.message);
     }
 
+    // 3. Valetudo map snapshots (REST API — works on robots without SSH file access)
+    const registeredSnapshotIds = new Set(config.floors.map((f) => f.snapshotId).filter(Boolean));
+    try {
+      const snapshots = await this._api.getMapSnapshots();
+      for (const snapshot of (snapshots || [])) {
+        if (registeredSnapshotIds.has(snapshot.id)) continue;
+        result.push({ type: 'snapshot', snapshotId: snapshot.id, timestamp: snapshot.timestamp });
+      }
+    } catch (err) {
+      this._log('Snapshot scan failed (robot may not support MapSnapshotCapability):', err.message);
+    }
+
     return result;
   }
 
@@ -644,10 +683,20 @@ class FloorManager {
     if (mapInfo.type === 'saved') {
       // Directory already on robot at correct path — just register it
       if (!config.floors.find((f) => f.id === id)) {
-        config.floors.push({ id, name, hasDock: true });
+        config.floors.push({ id, name, hasDock: true, sshBacked: true });
         await this._setStore(config);
       }
       this._log(`Registered existing floor directory "${id}" as "${name}"`);
+      return { id, name };
+    }
+
+    if (mapInfo.type === 'snapshot') {
+      // REST API snapshot — no SSH needed
+      if (!config.floors.find((f) => f.id === id)) {
+        config.floors.push({ id, name, hasDock: true, snapshotId: mapInfo.snapshotId });
+        await this._setStore(config);
+      }
+      this._log(`Registered snapshot "${mapInfo.snapshotId}" as floor "${name}"`);
       return { id, name };
     }
 
@@ -660,7 +709,7 @@ class FloorManager {
     if (!verified) throw new Error(`Map import verification failed for "${name}"`);
 
     if (!config.floors.find((f) => f.id === id)) {
-      config.floors.push({ id, name, hasDock: true, sourceFirmwareMap: mapInfo.fileName });
+      config.floors.push({ id, name, hasDock: true, sshBacked: true, sourceFirmwareMap: mapInfo.fileName });
       await this._setStore(config);
     }
     this._log(`Imported firmware map "${mapInfo.fileName}" as floor "${name}"`);

--- a/lib/ValetudoApi.js
+++ b/lib/ValetudoApi.js
@@ -94,6 +94,14 @@ class ValetudoApi {
     return data;
   }
 
+  async restoreMapSnapshot(id) {
+    const { data } = await this._client.put(
+      '/api/v2/robot/capabilities/MapSnapshotCapability',
+      { action: 'restore', id },
+    );
+    return data;
+  }
+
   // --- Speaker ---
 
   async getSpeakerVolume() {

--- a/lib/ValetudoDevice.js
+++ b/lib/ValetudoDevice.js
@@ -676,6 +676,11 @@ class ValetudoDevice extends Homey.Device {
           // Preserve original floor ID and reconstruct readable name from slug
           id = mapInfo.dirName;
           name = mapInfo.dirName.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+        } else if (mapInfo.type === 'snapshot') {
+          id = `snapshot_${mapInfo.snapshotId}`;
+          const date = mapInfo.timestamp ? new Date(mapInfo.timestamp).toLocaleDateString() : `${nextNum}`;
+          name = `Floor ${date}`;
+          nextNum++;
         } else {
           id = `floor_${nextNum}`;
           name = `Floor ${nextNum}`;


### PR DESCRIPTION
## Summary
- Adds REST API fallback for floor switching using Valetudo's `MapSnapshotCapability`
- Snapshots are auto-discovered alongside SSH/firmware maps when the device connects, and registered as floors with a `snapshotId`
- Floor switch logic: snapshot-only floors go straight to REST restore; SSH-backed floors try SSH first, fall back to snapshot if available
- Adds `restoreMapSnapshot(id)` to `ValetudoApi`

## ⚠️ Roborock only

`MapSnapshotCapability` is implemented in Valetudo **only for Roborock robots**. This fallback does **not** help Eureka/Midea robots — Valetudo does not expose Midea's native multi-map firmware slots via any API. See #83 for details.

This is still useful for Roborock users who haven't configured SSH credentials — they can switch between floors using the robot's own snapshot history via REST alone.

## How it works
1. On connect, `discoverAdditionalMaps()` queries `MapSnapshotCapability` in addition to SSH scans
2. Snapshot-based floors are stored with `{ snapshotId, hasDock }` — no SSH required
3. `switchFloor()` detects snapshot-only floors and calls `_switchFloorViaSnapshot()` directly
4. For SSH-backed floors with no saved map, `snapshotId` is used as a last resort

## Test plan
- [x] 198 unit tests passing
- [x] `homey app validate` passes at `publish` level
- [ ] Manual test on Roborock: SSH-based switching still works as before
- [ ] Manual test on Roborock without SSH: snapshot floors appear after connect, switching works via REST

🤖 Generated with [Claude Code](https://claude.com/claude-code)